### PR TITLE
Remove specific path triggers from CI workflows

### DIFF
--- a/.github/workflows/pulumi-test.yml
+++ b/.github/workflows/pulumi-test.yml
@@ -2,15 +2,11 @@ name: Unit Test (Pulumi)
 
 on:
   push:
-    paths:
-      - 'pulumi/**'
   pull_request:
     branches:
       - main
       - develop
       - 'release/**'
-    paths:
-      - 'pulumi/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,15 +2,11 @@ name: Unit Test (Python)
 
 on:
   push:
-    paths:
-      - 'python/python_module'
   pull_request:
     branches:
       - main
       - develop
       - 'release/**'
-    paths:
-      - 'python/python_module'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Eliminate specific path triggers for Pulumi and Python test workflows to streamline the CI process.