### PR TITLE
Add Rust and additional SDK support to devcontainer configuration

### DIFF
--- a/.code-workspace
+++ b/.code-workspace
@@ -15,6 +15,10 @@
         {
             "path": "pulumi",
             "name": "pulumi"
+        },
+        {
+            "path": "crates",
+            "name": "Rust"
         }
     ],
     "settings": {

--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,1 +1,0 @@
-eval "$(starship init bash)"

--- a/.devcontainer/.gitconfig
+++ b/.devcontainer/.gitconfig
@@ -1,2 +1,0 @@
-[commit]
-gpgSign = true

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,5 @@
 FROM mcr.microsoft.com/devcontainers/base:debian
+
+USER vscode
+
+RUN echo 'eval "$(starship init bash)"' >> ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
         "christian-kohler.path-intellisense",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "rust-lang.rust-analyzer"
       ]
     }
   },
@@ -23,6 +24,9 @@
     "ghcr.io/devcontainers/features/terraform": {},
     "ghcr.io/enricosecondulfo/devcontainer-features/volta": {},
     "ghcr.io/devcontainers/features/rust": {},
-    "ghcr.io/devcontainers-extra/features/starship": {}
+    "ghcr.io/devcontainers-extra/features/starship": {},
+    "ghcr.io/devcontainers/features/go": {},
+    "ghcr.io/devcontainers/features/java": {},
+    "ghcr.io/devcontainers-extra/features/gradle-sdkman": {}
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
     "ghcr.io/devcontainers/features/aws-cli": {},
     "ghcr.io/devcontainers/features/terraform": {},
     "ghcr.io/enricosecondulfo/devcontainer-features/volta": {},
-    "ghcr.io/devcontainers/features/rust": {}
+    "ghcr.io/devcontainers/features/rust": {},
+    "ghcr.io/devcontainers-extra/features/starship": {}
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,12 @@
       ]
     }
   },
-  "forwardPorts": []
+  "forwardPorts": [],
+  "features": {
+    "ghcr.io/devcontainers-extra/features/poetry": {},
+    "ghcr.io/devcontainers/features/aws-cli": {},
+    "ghcr.io/devcontainers/features/terraform": {},
+    "ghcr.io/enricosecondulfo/devcontainer-features/volta": {},
+    "ghcr.io/devcontainers/features/rust": {}
+  }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directory: '/packages'
+    directory: '/'
     schedule:
       interval: 'daily'
     target-branch: 'main'
@@ -13,7 +13,7 @@ updates:
       - 'nodejs'
 
   - package-ecosystem: 'cargo'
-    directory: '/crates'
+    directory: '/'
     schedule:
       interval: 'daily'
     target-branch: 'main'


### PR DESCRIPTION
Enhance the devcontainer setup by adding support for Rust, Go, Java, and Gradle SDKMan, while also cleaning up unused files and updating the Dockerfile for better initialization. Update the dependabot configuration to monitor packages from the root directory.