### PR TITLE
Refactor and implement GraphQL schema with error handling

### DIFF
--- a/crates/rust-lambda-graphql/src/lib.rs
+++ b/crates/rust-lambda-graphql/src/lib.rs
@@ -58,6 +58,7 @@ pub async fn function_handler(
         let response_body = match serde_json::to_string(&gql_response) {
             Ok(body) => body,
             Err(err) => {
+                lambda_http::tracing::error!("Failed to serialize response: {}", err);
                 return Ok(lambda_http::Response::builder()
                     .status(500)
                     .header("content-type", "application/json")

--- a/crates/rust-lambda-graphql/src/lib.rs
+++ b/crates/rust-lambda-graphql/src/lib.rs
@@ -1,0 +1,91 @@
+pub(crate) mod query;
+
+static SCHEMA: tokio::sync::OnceCell<
+    async_graphql::Schema<
+        query::QueryRoot,
+        async_graphql::EmptyMutation,
+        async_graphql::EmptySubscription,
+    >,
+> = tokio::sync::OnceCell::const_new();
+async fn init_schema() -> &'static async_graphql::Schema<
+    query::QueryRoot,
+    async_graphql::EmptyMutation,
+    async_graphql::EmptySubscription,
+> {
+    SCHEMA
+        .get_or_init(|| async {
+            let schema: async_graphql::Schema<
+                query::QueryRoot,
+                async_graphql::EmptyMutation,
+                async_graphql::EmptySubscription,
+            > = async_graphql::Schema::build(
+                query::QueryRoot,
+                async_graphql::EmptyMutation,
+                async_graphql::EmptySubscription,
+            )
+            .finish();
+            schema
+        })
+        .await
+}
+
+pub async fn function_handler(
+    event: lambda_http::Request,
+) -> Result<lambda_http::Response<lambda_http::Body>, lambda_http::Error> {
+    let schema = init_schema().await;
+
+    if event.method() == lambda_http::http::Method::POST {
+        // GraphQL Execution
+        let request_body = event.body();
+
+        let gql_request = match serde_json::from_slice::<async_graphql::Request>(request_body) {
+            Ok(request) => request,
+            Err(err) => {
+                return Ok(lambda_http::Response::builder()
+                    .status(400)
+                    .header("content-type", "application/json")
+                    .body(
+                        serde_json::json!({"error": format!("Invalid request body: {}", err)})
+                            .to_string()
+                            .into(),
+                    )
+                    .map_err(Box::new)?);
+            }
+        };
+
+        let gql_response = schema.execute(gql_request).await;
+
+        let response_body = match serde_json::to_string(&gql_response) {
+            Ok(body) => body,
+            Err(err) => {
+                return Ok(lambda_http::Response::builder()
+                    .status(500)
+                    .header("content-type", "application/json")
+                    .body(
+                        serde_json::json!({"error": format!("Failed to serialize response: {}", err)})
+                            .to_string()
+                            .into(),
+                    )
+                    .map_err(Box::new)?);
+            }
+        };
+
+        Ok(lambda_http::Response::builder()
+            .status(200)
+            .header("content-type", "application/json")
+            .body(response_body.into())
+            .map_err(Box::new)?)
+    } else {
+        // Error Response - Method Not Allowed
+        let response = lambda_http::Response::builder()
+            .status(405)
+            .header("content-type", "application/json")
+            .body(
+                serde_json::json!({"error":"Method Not Allowed"})
+                    .to_string()
+                    .into(),
+            )
+            .map_err(Box::new)?;
+        Ok(response)
+    }
+}

--- a/crates/rust-lambda-graphql/src/main.rs
+++ b/crates/rust-lambda-graphql/src/main.rs
@@ -1,78 +1,8 @@
-use async_graphql::{EmptyMutation, EmptySubscription, Schema};
-use lambda_http::{http::Method, run, service_fn, tracing, Body, Error, Request, Response};
-use serde_json::json;
-
-mod query;
-
-static SCHEMA: tokio::sync::OnceCell<Schema<query::QueryRoot, EmptyMutation, EmptySubscription>> =
-    tokio::sync::OnceCell::const_new();
-async fn init_schema() -> &'static Schema<query::QueryRoot, EmptyMutation, EmptySubscription> {
-    SCHEMA
-        .get_or_init(|| async {
-            let schema: Schema<query::QueryRoot, EmptyMutation, EmptySubscription> =
-                Schema::build(query::QueryRoot, EmptyMutation, EmptySubscription).finish();
-            schema
-        })
-        .await
-}
-
-async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
-    let schema = init_schema().await;
-
-    if event.method() == Method::POST {
-        // GraphQL Execution
-        let request_body = event.body();
-
-        let gql_request = match serde_json::from_slice::<async_graphql::Request>(request_body) {
-            Ok(request) => request,
-            Err(err) => {
-                return Ok(Response::builder()
-                    .status(400)
-                    .header("content-type", "application/json")
-                    .body(
-                        json!({"error": format!("Invalid request body: {}", err)})
-                            .to_string()
-                            .into(),
-                    )
-                    .map_err(Box::new)?);
-            }
-        };
-
-        let gql_response = schema.execute(gql_request).await;
-
-        let response_body = match serde_json::to_string(&gql_response) {
-            Ok(body) => body,
-            Err(err) => {
-                return Ok(Response::builder()
-                    .status(500)
-                    .header("content-type", "application/json")
-                    .body(
-                        json!({"error": format!("Failed to serialize response: {}", err)})
-                            .to_string()
-                            .into(),
-                    )
-                    .map_err(Box::new)?);
-            }
-        };
-
-        Ok(Response::builder()
-            .status(200)
-            .header("content-type", "application/json")
-            .body(response_body.into())
-            .map_err(Box::new)?)
-    } else {
-        // Error Response - Method Not Allowed
-        let response = Response::builder()
-            .status(405)
-            .header("content-type", "application/json")
-            .body(json!({"error":"Method Not Allowed"}).to_string().into())
-            .map_err(Box::new)?;
-        Ok(response)
-    }
-}
-
 #[tokio::main]
-async fn main() -> Result<(), Error> {
-    tracing::init_default_subscriber();
-    run(service_fn(function_handler)).await
+async fn main() -> Result<(), lambda_http::Error> {
+    lambda_http::tracing::init_default_subscriber();
+    lambda_http::run(lambda_http::service_fn(
+        rust_lambda_graphql::function_handler,
+    ))
+    .await
 }

--- a/crates/rust-lambda-graphql/src/query.rs
+++ b/crates/rust-lambda-graphql/src/query.rs
@@ -4,56 +4,21 @@ pub struct QueryRoot;
 
 #[async_graphql::Object]
 impl QueryRoot {
-    /// Returns a greeting message along with the programming language.
-    pub async fn greet(
-        &self,
-        ctx: &async_graphql::Context<'_>,
-    ) -> Result<Greet, async_graphql::Error> {
-        Greet::new(ctx)
+    pub async fn factorial(&self, number: u64) -> u64 {
+        (1..=number).product()
     }
-}
 
-pub struct Greet {
-    pub message: String,
-    pub language: String,
-    pub accept_encoding: Option<Vec<String>>,
-}
-
-impl Greet {
-    pub fn new(ctx: &async_graphql::Context) -> Result<Self, async_graphql::Error> {
-        let accept_encoding = ctx
-            .data::<lambda_http::http::HeaderMap<lambda_http::http::HeaderValue>>()
-            .ok()
-            .and_then(|headers| headers.get("accept-encoding"))
-            .and_then(|header| header.to_str().ok())
-            .map(|header| {
-                header
-                    .split(",")
-                    .map(|s| s.trim().to_string())
-                    .collect::<Vec<String>>()
-            });
-
+    /// Returns a greeting message along with the programming language.
+    pub async fn greet(&self) -> Result<Greet, async_graphql::Error> {
         Ok(Greet {
-            message: "Hello, GraphQL!".to_string(),
+            message: "Hello, World!".to_string(),
             language: "Rust".to_string(),
-            accept_encoding,
         })
     }
 }
 
-#[async_graphql::Object]
-impl Greet {
-    /// A delightful message from the server
-    pub async fn message(&self) -> String {
-        self.message.to_string()
-    }
-
-    /// Languages that implement GraphQL
-    pub async fn language(&self) -> String {
-        self.language.to_string()
-    }
-
-    pub async fn accept_encoding(&self) -> Option<Vec<String>> {
-        self.accept_encoding.clone()
-    }
+#[derive(async_graphql::SimpleObject)]
+pub struct Greet {
+    pub message: String,
+    pub language: String,
 }

--- a/crates/rust-lambda-graphql/src/query.rs
+++ b/crates/rust-lambda-graphql/src/query.rs
@@ -4,8 +4,8 @@ pub struct QueryRoot;
 
 #[async_graphql::Object]
 impl QueryRoot {
-    pub async fn factorial(&self, number: u64) -> u64 {
-        (1..=number).product()
+    pub async fn factorial(&self, number: u64) -> Result<u64, async_graphql::Error> {
+        Ok((1..=number).product())
     }
 
     /// Returns a greeting message along with the programming language.


### PR DESCRIPTION
Initialize the GraphQL schema using OnceCell for better performance, implement factorial and greeting queries, and enhance error handling for serialization failures.