### PR TITLE
feat(stacks): add agentcore-harness example stack

### DIFF
--- a/stacks/README.md
+++ b/stacks/README.md
@@ -25,4 +25,5 @@ time (e.g. `uv export` → `requirements.txt`) rather than shipping the whole wo
 
 | Stack                                            | What                                                                                                                              |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| [`agentcore-harness`](./agentcore-harness)       | Minimal Amazon Bedrock AgentCore harness (managed, config-only agent): execution role + `awscc` harness with managed memory.       |
 | [`agentcore-web-search`](./agentcore-web-search) | Web Search on Amazon Bedrock AgentCore: Gateway + web-search connector, ECR, Runtime, and Strands web-search + synthesize agents. |

--- a/stacks/agentcore-harness/README.md
+++ b/stacks/agentcore-harness/README.md
@@ -1,0 +1,54 @@
+# agentcore-harness
+
+A minimal **Amazon Bedrock AgentCore harness** ("hello harness"): you _declare_ an
+agent (just a default model) and AgentCore runs the orchestration loop, sandboxed
+compute, memory, identity, and observability for you. No agent code, no container.
+
+Contrast with [`agentcore-web-search`](../agentcore-web-search), which uses the
+**Runtime** path — you bring Strands code in a container and wire the primitives
+yourself. The harness is the managed, config-only path (it runs _inside_ Runtime).
+
+## What gets created
+
+| Resource | Purpose |
+| --- | --- |
+| `aws_iam_role.harness` | Execution role the harness assumes (Bedrock invoke, logs, tracing, workload identity, and memory `*Event`/`RetrieveMemoryRecords` — the runtime reads/writes memory with this role). |
+| `awscc_bedrockagentcore_harness.this` | The harness itself: one default model, built-in `shell` + `file_operations` tools, managed memory. |
+
+A **managed AgentCore Memory** is auto-provisioned (because the `memory` block is
+omitted): `SEMANTIC` + `SUMMARIZATION` strategies, 30-day event expiry. It gives
+multi-turn continuity keyed on the runtime session id, and cascade-deletes with
+the harness.
+
+## Deploy & invoke
+
+```sh
+just deploy     # terraform init + apply
+just invoke     # streams two turns through the deployed harness
+just destroy
+```
+
+`just invoke` runs `invoke.py` twice with the **same** `runtimeSessionId` — it
+tells the agent a name, then asks for it back, demonstrating that you send only
+the new message and the harness reloads history from memory itself.
+
+## Notes & decisions
+
+- **Region** is pinned to `us-east-1`. The default model is Moonshot **Kimi K2.5**
+  (`moonshotai.kimi-k2.5`), served through the OpenAI-compatible **Bedrock Mantle**
+  endpoint by setting `api_format = "chat_completions"` (`responses` also works).
+  Kimi K2.5 is available in-region in us-east-1, so no inference profile / `us.`
+  prefix is needed. Override the model or `api_format` per `InvokeHarness` call to
+  swap models mid-session.
+- **Provider:** the harness is not yet in the native `hashicorp/aws` provider, so
+  it is provisioned through **`awscc`** (`AWS::BedrockAgentCore::Harness` via Cloud
+  Control). Confirm/bump the `awscc` version floor in `provider.tf` against the
+  registry — the resource must exist in the version you resolve.
+- **Caller IAM:** the principal running `terraform apply` needs `CreateHarness`
+  **plus** `CreateAgentRuntime` and `CreateMemory` (the harness wraps a Runtime and
+  provisions the managed Memory).
+- **Memory in Terraform:** `awscc` exposes only managed-default (omit `memory`) or
+  bring-your-own (`memory = { agent_core_memory_configuration = { arn = ... } }`).
+  The API's managed-strategy tuning and `disabled` mode are not expressible yet.
+- **Pricing:** no separate harness charge — you pay only for the underlying
+  AgentCore services (Runtime, Memory, model inference) consumed.

--- a/stacks/agentcore-harness/invoke.py
+++ b/stacks/agentcore-harness/invoke.py
@@ -1,0 +1,60 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.35"]
+# ///
+# pyright: basic
+# boto3 ships only partial type information for its dynamic clients, so the
+# harness client and its streaming response are loosely typed here.
+"""Invoke an AgentCore harness and stream the reply.
+
+Runs two turns with the SAME runtimeSessionId to show that the harness's managed
+short-term memory carries the conversation: the second turn asks about something
+stated in the first, and it is never re-sent.
+
+Usage:
+    uv run --script invoke.py <harnessArn> [region]
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+
+import boto3
+
+
+def stream(client, harness_arn: str, session_id: str, text: str) -> None:
+    print(f"\n>>> {text}")
+    response = client.invoke_harness(
+        harnessArn=harness_arn,
+        runtimeSessionId=session_id,
+        messages=[{"role": "user", "content": [{"text": text}]}],
+    )
+    for event in response["stream"]:
+        if "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                print(delta["text"], end="", flush=True)
+        elif "runtimeClientError" in event:
+            print(f"\n[error] {event['runtimeClientError']['message']}")
+    print()
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("usage: uv run --script invoke.py <harnessArn> [region]")
+    harness_arn = sys.argv[1]
+    region = sys.argv[2] if len(sys.argv) > 2 else "us-east-1"
+
+    client = boto3.client("bedrock-agentcore", region_name=region)
+
+    # The session id must be >= 33 chars; reuse it across turns so the harness
+    # loads the prior history from memory before reasoning.
+    session_id = f"{uuid.uuid4().hex}{uuid.uuid4().hex}"
+
+    stream(client, harness_arn, session_id, "Hi! My name is Ikuma. Please remember it.")
+    stream(client, harness_arn, session_id, "What is my name?")
+
+
+if __name__ == "__main__":
+    main()

--- a/stacks/agentcore-harness/justfile
+++ b/stacks/agentcore-harness/justfile
@@ -1,0 +1,27 @@
+# Orchestration for the agentcore-harness stack.
+# Requires: terraform, the aws CLI, uv, and just.
+
+tf := "terraform -chdir=terraform"
+region := "us-east-1"
+
+default:
+    @just --list
+
+init:
+    {{tf}} init
+
+# Provision the execution role + harness (managed memory auto-provisions).
+deploy: init
+    {{tf}} apply
+
+# Stream two turns through the deployed harness, reusing one session id to show
+# managed short-term memory carrying the conversation.
+invoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ARN=$({{tf}} output -raw harness_arn)
+    uv run --script invoke.py "$ARN" {{region}}
+
+# Tear down. The managed memory cascade-deletes with the harness by default.
+destroy:
+    {{tf}} destroy

--- a/stacks/agentcore-harness/terraform/.terraform.lock.hcl
+++ b/stacks/agentcore-harness/terraform/.terraform.lock.hcl
@@ -1,0 +1,70 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.51.0"
+  constraints = ">= 6.22.0"
+  hashes = [
+    "h1:bclp+xS1fYeOCil0XZO6mKvEeHFESt5K/XotVSZND54=",
+    "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
+    "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
+    "zh:190a46da0c69082b74da48238ce134d2fc9893e09122ac249c5689f88eab7e13",
+    "zh:1b312a4b53fa3cf731f95e674c033865feea5455f163b86136f2614424637293",
+    "zh:2b319814806222c5aba196b1a78756a6b36dc5c91f85edda349234d8a2f20a6a",
+    "zh:2bddf92c8efc6ad445a2eb8a0e5f88742a0596392c3a4ebc350ebb4105a4a96d",
+    "zh:3bef0c4f675c09034ff017cf899977b1765b2c0b3d1e489bcb06a5fcac316e2d",
+    "zh:47c46b5aa22199638fed5c93b195bbfd1182a1408edad4e5c39d4a73a04493f6",
+    "zh:5f808699650f6db961964466c77f5a581eab142a91c2e54810bb09b6f2fcd3f2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ada97e6be10164f452e278c23412b8597698a9c95ffb68fe83629d63d85906f3",
+    "zh:c4d73a91810d8dbcf9abbd431d41fcceebb48f8b6fd3c28a84bb3c6ed08be2e9",
+    "zh:c63ec875d38fc557b16b0b2b0ab1c7635852799453113240e21a52409de94a71",
+    "zh:cdd0209a755fc3aa14855aa013dae4b166a2fc7f6d3cbb673f7ff2142f5b63a2",
+    "zh:e5e665a27290391fd1bffc093ab68b596f6c507785be2e3f0949fab4fd6aec1b",
+    "zh:f6c42046a31d65eff2793737656b38931f90318b53661046bb84326cd4cb558f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/awscc" {
+  version     = "1.89.0"
+  constraints = ">= 1.60.0"
+  hashes = [
+    "h1:QZYfne5HgtW+iL0SCZXNIspeDQUIBty+5clq754wXWg=",
+    "zh:2589d15db6a9a180ac1b021341c1225b9cae59a7d7003c05b787b91ccade504f",
+    "zh:446d9b1ae47dcf26b8ef49ea2ad3013a406adc33b24c7460d33c779021161f70",
+    "zh:44927f518b28a5a454a479e4c0eb8021709217cc51c4b1f8b51203cf8f8fa1c4",
+    "zh:521b1a2d757cf9d41ee3d412b6026b4483c905b92724b98372357bcb22ab43a3",
+    "zh:719b4f9608d394bc40e8e23d057e9693be2035dca48ad0bbc65e9025bd31c209",
+    "zh:7ea429e5541af0cd45e87ad9a6d5a56dd91e593413f24ef4935fa6a16930a1ed",
+    "zh:b6103766e0094296fcd63ac414597cff3d1e1f2491b7de7e8dfd8fc9ad915fd2",
+    "zh:c2f0ea3039ce2a2433d9839ce04cfdb98652f76c6ee3a69d389f4036785417f1",
+    "zh:d0da4cfccc05ec2a9e961be468e2e98cea12a331262d3e524a402150f4884db2",
+    "zh:d17d19cb0337d5e3677e969f09bf0d67dfe286d8e1f34d150430e0d076fda9e1",
+    "zh:d2972f77c2254759ed0d44fac72b48bfe5701d6b9327f49ce26ce4551cd42884",
+    "zh:dcec5e6970dbf90624dfe648df7e8b3fa2963d3c5cbd1e0748dbad9a2eea097e",
+    "zh:dfffb14a9818224ae7004dda8c259439afdc94aabe208793fe24d2c9760b2b14",
+    "zh:f03ee3c782533a2e04bccbdc2291e1922b6bfabcd03a5a1be4f8a97059bef4d1",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:4EThC3ocCFiFPMZQSUvSGSxoJqBcGWxMcFYmL67uS7Y=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}

--- a/stacks/agentcore-harness/terraform/harness.tf
+++ b/stacks/agentcore-harness/terraform/harness.tf
@@ -1,0 +1,44 @@
+# --- AgentCore harness --------------------------------------------------------
+# A declarative agent: a default model and nothing else. The built-in `shell` and
+# `file_operations` tools are always present, so no `tools` or `skills` are
+# configured here.
+#
+# `memory` is intentionally omitted. That triggers the GA managed default: an
+# auto-provisioned, customer-owned AgentCore Memory (SEMANTIC + SUMMARIZATION
+# strategies, 30-day event expiry) giving multi-turn continuity keyed on the
+# runtime session id (and actor id, if passed). It cascade-deletes with the
+# harness. To go stateless instead you would attach a BYO memory ARN via
+# `memory = { agent_core_memory_configuration = { arn = ... } }` — awscc does not
+# expose the API's managed-tuning or `disabled` options, so managed-default
+# (omit) vs BYO-ARN are the two paths available in Terraform today.
+#
+# Provisioned through awscc because the harness is not yet in hashicorp/aws.
+
+# IAM is eventually consistent: AgentCore Control assumes the execution role to
+# validate it during CreateHarness. On a from-scratch apply the role may not have
+# propagated to the service yet, surfacing as "Role validation failed". Give
+# propagation a brief head start before creating the harness.
+resource "time_sleep" "role_propagation" {
+  depends_on      = [aws_iam_role_policy.harness]
+  create_duration = "20s"
+}
+
+resource "awscc_bedrockagentcore_harness" "this" {
+  harness_name       = var.harness_name
+  execution_role_arn = aws_iam_role.harness.arn
+
+  model = {
+    bedrock_model_config = {
+      model_id = var.model_id
+      # Selects the protocol and Bedrock endpoint: chat_completions / responses
+      # route through the OpenAI-compatible bedrock-mantle endpoint (Kimi K2.5),
+      # converse_stream uses the native bedrock-runtime Converse API.
+      api_format = var.api_format
+    }
+  }
+
+  max_iterations  = var.max_iterations
+  timeout_seconds = var.timeout_seconds
+
+  depends_on = [time_sleep.role_propagation]
+}

--- a/stacks/agentcore-harness/terraform/iam.tf
+++ b/stacks/agentcore-harness/terraform/iam.tf
@@ -1,0 +1,131 @@
+# --- Harness execution role ---------------------------------------------------
+# The IAM role the AgentCore harness assumes while it runs: invoke Bedrock for
+# inference, pull the managed Strands base image from public ECR, emit traces and
+# logs, and mint a workload-identity token. This mirrors the AWS-documented
+# minimal harness execution role (the same set the AgentCore CLI generates).
+#
+# Note: the harness runtime reads and writes memory using THIS role, so even the
+# auto-provisioned managed memory needs the *Event / RetrieveMemoryRecords grant
+# below — despite the AWS docs framing that statement as "customer-owned" only.
+# The managed memory is named harness_<harnessName>_<suffix>, so the ARN isn't
+# known until create; we scope to that prefix rather than naming the instance.
+
+data "aws_iam_policy_document" "harness_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "harness" {
+  name               = "${var.name_prefix}-exec-role"
+  assume_role_policy = data.aws_iam_policy_document.harness_assume.json
+}
+
+data "aws_iam_policy_document" "harness" {
+  statement {
+    sid    = "BedrockModelInvocation"
+    effect = "Allow"
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+    # Geo cross-region inference fans the request across the US regions, so allow
+    # the inference profile plus the foundation models it routes to. Scope down to
+    # a specific inference-profile ARN for production.
+    resources = [
+      "arn:aws:bedrock:*::foundation-model/*",
+      "arn:aws:bedrock:*:${local.account_id}:inference-profile/*",
+    ]
+  }
+
+  statement {
+    sid       = "EcrPublicPull"
+    effect    = "Allow"
+    actions   = ["ecr-public:GetAuthorizationToken", "sts:GetServiceBearerToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Tracing"
+    effect = "Allow"
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "LogsGroup"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup", "logs:DescribeLogStreams"]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*"]
+  }
+
+  statement {
+    sid       = "LogsDescribeGroups"
+    effect    = "Allow"
+    actions   = ["logs:DescribeLogGroups"]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:*"]
+  }
+
+  statement {
+    sid       = "LogsStream"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*"]
+  }
+
+  statement {
+    sid       = "Metrics"
+    effect    = "Allow"
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = ["bedrock-agentcore"]
+    }
+  }
+
+  statement {
+    sid    = "WorkloadIdentity"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:GetWorkloadAccessToken",
+      "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/default",
+      "arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/default/workload-identity/harness_${var.harness_name}-*",
+    ]
+  }
+
+  statement {
+    sid    = "AgentCoreMemory"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:CreateEvent",
+      "bedrock-agentcore:DeleteEvent",
+      "bedrock-agentcore:GetEvent",
+      "bedrock-agentcore:ListEvents",
+      "bedrock-agentcore:RetrieveMemoryRecords",
+    ]
+    resources = ["arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:memory/harness_${var.harness_name}_*"]
+  }
+}
+
+resource "aws_iam_role_policy" "harness" {
+  name   = "harness"
+  role   = aws_iam_role.harness.id
+  policy = data.aws_iam_policy_document.harness.json
+}

--- a/stacks/agentcore-harness/terraform/locals.tf
+++ b/stacks/agentcore-harness/terraform/locals.tf
@@ -1,0 +1,6 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  region     = "us-east-1"
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/stacks/agentcore-harness/terraform/outputs.tf
+++ b/stacks/agentcore-harness/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "harness_arn" {
+  description = "ARN of the AgentCore harness (pass to InvokeHarness)."
+  value       = awscc_bedrockagentcore_harness.this.arn
+}
+
+output "harness_id" {
+  description = "Identifier of the AgentCore harness."
+  value       = awscc_bedrockagentcore_harness.this.harness_id
+}
+
+output "harness_status" {
+  description = "Provisioning status of the harness (READY when invokable)."
+  value       = awscc_bedrockagentcore_harness.this.status
+}
+
+output "invoke_command" {
+  description = "Copy-paste command to stream two turns through the harness."
+  value       = "uv run --script invoke.py ${awscc_bedrockagentcore_harness.this.arn}"
+}

--- a/stacks/agentcore-harness/terraform/provider.tf
+++ b/stacks/agentcore-harness/terraform/provider.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # aws_iam_role / aws_caller_identity only; any recent version is fine.
+      version = ">= 6.22"
+    }
+    awscc = {
+      source = "hashicorp/awscc"
+      # The harness is not yet in the native hashicorp/aws provider, so it is
+      # provisioned through awscc (AWS Cloud Control). awscc_bedrockagentcore_harness
+      # maps AWS::BedrockAgentCore::Harness, which GA'd June 2026. Use the latest
+      # awscc; bump this floor if `terraform init` reports the resource is unknown.
+      version = ">= 1.60"
+    }
+    time = {
+      source = "hashicorp/time"
+      # Used to let the freshly-created execution role propagate to AgentCore
+      # before CreateHarness validates it.
+      version = ">= 0.9"
+    }
+  }
+}
+
+# The harness is GA in every AgentCore region; this example pins us-east-1.
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "awscc" {
+  region = "us-east-1"
+}

--- a/stacks/agentcore-harness/terraform/variables.tf
+++ b/stacks/agentcore-harness/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "name_prefix" {
+  description = "Prefix applied to resource names (IAM role, etc.). Hyphens allowed here; the harness name has its own variable because it forbids them."
+  type        = string
+  default     = "46ki75-agentcore-harness"
+}
+
+variable "harness_name" {
+  description = "Name of the AgentCore harness. AWS pattern ^[a-zA-Z][a-zA-Z0-9_]{0,39}$ — letters, digits, and underscores only (no hyphens), max 40 chars."
+  type        = string
+  default     = "hello_harness"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_]{0,39}$", var.harness_name))
+    error_message = "harness_name must match ^[a-zA-Z][a-zA-Z0-9_]{0,39}$ (no hyphens)."
+  }
+}
+
+variable "model_id" {
+  description = "Default Bedrock model the harness reasons with. Kimi K2.5 is available in-region in us-east-1 (no geo/global inference profile), so the plain model ID is used. Override per InvokeHarness call to swap models mid-session."
+  type        = string
+  default     = "moonshotai.kimi-k2.5"
+}
+
+variable "api_format" {
+  description = "Bedrock API protocol + endpoint the harness calls: 'converse_stream' (Converse on bedrock-runtime, the default for most models), or 'responses'/'chat_completions' (OpenAI-compatible, served by the bedrock-mantle endpoint). Kimi K2.5 is served via Mantle."
+  type        = string
+  default     = "chat_completions"
+
+  validation {
+    condition     = contains(["converse_stream", "responses", "chat_completions"], var.api_format)
+    error_message = "api_format must be 'converse_stream', 'responses', or 'chat_completions'."
+  }
+}
+
+variable "max_iterations" {
+  description = "Max agent-loop iterations per invocation. Null uses the service default."
+  type        = number
+  default     = null
+}
+
+variable "timeout_seconds" {
+  description = "Max wall-clock seconds per invocation. Null uses the service default."
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
## What

Adds a new `stacks/agentcore-harness` deployable unit: a minimal **Amazon Bedrock AgentCore harness** — the managed, config-only agent path (declares model/tools/memory; AgentCore runs the orchestration loop). Contrasts with the existing `agentcore-web-search` stack, which uses the code-on-Runtime path.

## Details

- **`terraform/`** — execution role + `awscc_bedrockagentcore_harness` (the harness isn't in the native `hashicorp/aws` provider yet, so it's provisioned via `awscc` / Cloud Control). Pinned to **us-east-1**.
  - Default model: Moonshot **Kimi K2.5** (`moonshotai.kimi-k2.5`) over the **Bedrock Mantle** endpoint (`api_format = chat_completions`). In-region in us-east-1, so no inference profile needed.
  - **Memory enabled** by omitting the `memory` block → GA managed default (SEMANTIC + SUMMARIZATION, 30-day).
- **`invoke.py`** — boto3 two-turn invoke demonstrating managed short-term memory (states a name, then recalls it).
- **`justfile`** — `deploy` / `invoke` / `destroy`.
- Registered in `stacks/README.md`.

## Notes for reviewers (gotchas baked into comments)

- `time_sleep` between the role and the harness — `CreateHarness` validates (assumes) the execution role, and a from-scratch apply otherwise loses the IAM-propagation race ("Role validation failed").
- Managed memory **does** need execution-role memory IAM (`*Event` / `RetrieveMemoryRecords`), despite AWS docs framing that statement as BYO-only — found via a failed invoke.
- Caller running `terraform apply` needs `CreateHarness` + `CreateAgentRuntime` + `CreateMemory`.

## Verification

`terraform validate` passes; deployed live to `status = READY` and invoked end-to-end (Kimi K2.5 over Mantle, multi-turn memory confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)