### PR TITLE
feat(stacks): add web search tool to agentcore-harness

### DIFF
--- a/stacks/README.md
+++ b/stacks/README.md
@@ -7,7 +7,7 @@ and tool it needs side by side.
 
 ## Convention
 
-```
+```txt
 stacks/{unit}/
   README.md          # what it is, architecture, deploy order
   justfile           # orchestration across the sub-parts
@@ -23,7 +23,7 @@ time (e.g. `uv export` → `requirements.txt`) rather than shipping the whole wo
 
 ## Stacks
 
-| Stack                                            | What                                                                                                                              |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| [`agentcore-harness`](./agentcore-harness)       | Minimal Amazon Bedrock AgentCore harness (managed, config-only agent): execution role + `awscc` harness with managed memory.       |
-| [`agentcore-web-search`](./agentcore-web-search) | Web Search on Amazon Bedrock AgentCore: Gateway + web-search connector, ECR, Runtime, and Strands web-search + synthesize agents. |
+| Stack                                            | What                                                                                                                                                                       |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`agentcore-harness`](./agentcore-harness)       | Minimal Amazon Bedrock AgentCore harness (managed, config-only agent): `awscc` harness with managed memory + a Gateway-backed web-search tool (AWS_IAM/SigV4, no Cognito). |
+| [`agentcore-web-search`](./agentcore-web-search) | Web Search on Amazon Bedrock AgentCore: Gateway + web-search connector, ECR, Runtime, and Strands web-search + synthesize agents.                                          |

--- a/stacks/agentcore-harness/README.md
+++ b/stacks/agentcore-harness/README.md
@@ -1,19 +1,39 @@
 # agentcore-harness
 
-A minimal **Amazon Bedrock AgentCore harness** ("hello harness"): you _declare_ an
-agent (just a default model) and AgentCore runs the orchestration loop, sandboxed
-compute, memory, identity, and observability for you. No agent code, no container.
+A minimal **Amazon Bedrock AgentCore harness** with **web search**: you _declare_
+an agent (a default model plus a tool) and AgentCore runs the orchestration loop,
+sandboxed compute, memory, identity, and observability for you. No agent code, no
+container.
 
 Contrast with [`agentcore-web-search`](../agentcore-web-search), which uses the
 **Runtime** path — you bring Strands code in a container and wire the primitives
 yourself. The harness is the managed, config-only path (it runs _inside_ Runtime).
+Both reach the same managed Web Search, but the harness reaches it over **SigV4**,
+so it skips that example's whole Cognito + AgentCore Identity layer (see below).
+
+```txt
+caller ──InvokeHarness──▶ AgentCore Harness (AWS runs the loop · Claude Sonnet 4.6)
+                            │  built-in shell + file_operations
+                            │  agentcore_gateway tool
+                            │      │ SigV4 (harness execution role)
+                            │      ▼
+                            │  AgentCore Gateway (AWS_IAM inbound)
+                            │      └─ target: connector "web-search"
+                            │           │ GATEWAY_IAM_ROLE (SigV4)
+                            │           ▼
+                            │      AWS-managed Web Search
+                            └─ managed AgentCore Memory (multi-turn continuity)
+```
 
 ## What gets created
 
-| Resource | Purpose |
-| --- | --- |
-| `aws_iam_role.harness` | Execution role the harness assumes (Bedrock invoke, logs, tracing, workload identity, and memory `*Event`/`RetrieveMemoryRecords` — the runtime reads/writes memory with this role). |
-| `awscc_bedrockagentcore_harness.this` | The harness itself: one default model, built-in `shell` + `file_operations` tools, managed memory. |
+| Resource                              | Purpose                                                                                                                                                                      |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aws_iam_role.harness`                | Execution role the harness assumes (Bedrock invoke, logs, tracing, workload identity, memory `*Event`/`RetrieveMemoryRecords`, and `InvokeGateway` for the web-search tool). |
+| `aws_iam_role.gateway`                | Service role the Gateway assumes to reach managed Web Search (`InvokeGateway` + `InvokeWebSearch`).                                                                          |
+| `aws_bedrockagentcore_gateway.this`   | The Gateway, with an **AWS_IAM** inbound authorizer (no Cognito/JWT).                                                                                                        |
+| `terraform_data.web_search_target`    | Creates the built-in `web-search` connector target on the Gateway (via a boto3 helper — the `connector` type isn't modeled by the providers yet).                            |
+| `awscc_bedrockagentcore_harness.this` | The harness: one default model, built-in `shell` + `file_operations` tools, the `agentcore_gateway` web-search tool, and managed memory.                                     |
 
 A **managed AgentCore Memory** is auto-provisioned (because the `memory` block is
 omitted): `SEMANTIC` + `SUMMARIZATION` strategies, 30-day event expiry. It gives
@@ -23,32 +43,64 @@ the harness.
 ## Deploy & invoke
 
 ```sh
-just deploy     # terraform init + apply
+just deploy     # terraform init + apply (role, gateway + web-search target, harness)
 just invoke     # streams two turns through the deployed harness
 just destroy
 ```
 
-`just invoke` runs `invoke.py` twice with the **same** `runtimeSessionId` — it
-tells the agent a name, then asks for it back, demonstrating that you send only
-the new message and the harness reloads history from memory itself.
+`just invoke` runs `invoke.py` twice with the **same** `runtimeSessionId`. The
+first turn asks for current information, so the agent calls the Gateway's
+`web_search` tool and answers with cited sources; the second is a follow-up
+answered from managed memory (the result is never re-sent). Tool calls are
+surfaced inline as `[tool: ...]` so you can watch the search fire.
+
+## How the pieces fit
+
+- **Web search as a Gateway tool** — the harness `tools` block references the
+  Gateway by ARN (`agentcore_gateway`); every tool configured on that Gateway
+  (here, the built-in `web-search` connector) becomes callable. `allowed_tools`
+  is left unset, so all tools (the built-ins plus the gateway's) stay available.
+- **All IAM, no OAuth** — the Gateway uses an **AWS_IAM inbound authorizer**, so
+  callers are authorized by their IAM identity. The harness's default
+  `agentcore_gateway` outbound auth is **AWS IAM (SigV4)** signed with its own
+  execution role, which therefore just needs `bedrock-agentcore:InvokeGateway`
+  on the Gateway. That collapses the runtime example's Cognito user pool +
+  AgentCore Identity OAuth2 provider down to two IAM grants, because AWS runs the
+  loop and signs natively.
+- **Connector target** — the built-in `web-search` connector is created by a
+  small boto3 helper (`web_search_target.py`) invoked from `terraform_data`
+  (`gateway_target.tf`). Neither the native `aws_bedrockagentcore_gateway_target`
+  resource nor the bundled `aws` CLI model the `connector` target type yet, so
+  the helper runs as a self-contained PEP 723 script via `uv run --script` to use
+  a boto3 new enough to know the shape. Everything else is native Terraform/awscc.
+- **Gateway outbound** — the Gateway reaches the AWS-managed search backend with
+  its service role (`aws_iam_role.gateway`: `InvokeGateway` + `InvokeWebSearch`).
 
 ## Notes & decisions
 
-- **Region** is pinned to `us-east-1`. The default model is Moonshot **Kimi K2.5**
-  (`moonshotai.kimi-k2.5`), served through the OpenAI-compatible **Bedrock Mantle**
-  endpoint by setting `api_format = "chat_completions"` (`responses` also works).
-  Kimi K2.5 is available in-region in us-east-1, so no inference profile / `us.`
-  prefix is needed. Override the model or `api_format` per `InvokeHarness` call to
-  swap models mid-session.
+- **Model must be a native Converse tool-caller.** The default is Claude
+  **Sonnet 4.6** (`us.anthropic.claude-sonnet-4-6`, via its `us` geo inference
+  profile — Sonnet 4.6 has no in-region profile in us-east-1) with
+  `api_format = "converse_stream"`. Models served through the OpenAI-compatible
+  **Bedrock Mantle** endpoint (`chat_completions`/`responses`, e.g.
+  `moonshotai.kimi-k2.5`) emit OpenAI-style tool IDs (`functions.<name>:0`) that
+  the harness's tool-result schema rejects (`^[a-zA-Z0-9_-]+$`), so they only
+  work **tool-free**. Keep `converse_stream` whenever the `web_search` tool is
+  attached; override `model_id`/`api_format` for a tool-free harness.
+- **Region** is pinned to `us-east-1` (the only region where Web Search is
+  offered), for both the `aws` and `awscc` providers.
 - **Provider:** the harness is not yet in the native `hashicorp/aws` provider, so
   it is provisioned through **`awscc`** (`AWS::BedrockAgentCore::Harness` via Cloud
-  Control). Confirm/bump the `awscc` version floor in `provider.tf` against the
-  registry — the resource must exist in the version you resolve.
+  Control). The Gateway and IAM roles use native `hashicorp/aws`. Note `awscc`
+  exposes the `agentcore_gateway` tool but **not** the simpler native
+  `agentcore_web_search` tool type yet (it isn't in the CloudFormation schema), so
+  the Gateway path above is the declarative way to attach web search today.
 - **Caller IAM:** the principal running `terraform apply` needs `CreateHarness`
-  **plus** `CreateAgentRuntime` and `CreateMemory` (the harness wraps a Runtime and
-  provisions the managed Memory).
+  and `CreateGateway`/`CreateGatewayTarget`, **plus** `CreateAgentRuntime` and
+  `CreateMemory` (the harness wraps a Runtime and provisions the managed Memory).
 - **Memory in Terraform:** `awscc` exposes only managed-default (omit `memory`) or
   bring-your-own (`memory = { agent_core_memory_configuration = { arn = ... } }`).
   The API's managed-strategy tuning and `disabled` mode are not expressible yet.
 - **Pricing:** no separate harness charge — you pay only for the underlying
-  AgentCore services (Runtime, Memory, model inference) consumed.
+  AgentCore services (Runtime, Memory, model inference) consumed. Web Search is
+  billed at **$7 per 1,000 queries** (us-east-1).

--- a/stacks/agentcore-harness/invoke.py
+++ b/stacks/agentcore-harness/invoke.py
@@ -7,9 +7,11 @@
 # harness client and its streaming response are loosely typed here.
 """Invoke an AgentCore harness and stream the reply.
 
-Runs two turns with the SAME runtimeSessionId to show that the harness's managed
-short-term memory carries the conversation: the second turn asks about something
-stated in the first, and it is never re-sent.
+Runs two turns with the SAME runtimeSessionId. The first asks a question that
+needs current information, so the agent calls the Gateway-backed `web_search`
+tool; the second is a follow-up answered from the managed short-term memory of
+that result (it is never re-sent). Tool invocations are surfaced inline as
+``[tool: ...]`` so you can see the web search fire.
 
 Usage:
     uv run --script invoke.py <harnessArn> [region]
@@ -31,7 +33,11 @@ def stream(client, harness_arn: str, session_id: str, text: str) -> None:
         messages=[{"role": "user", "content": [{"text": text}]}],
     )
     for event in response["stream"]:
-        if "contentBlockDelta" in event:
+        if "contentBlockStart" in event:
+            tool = event["contentBlockStart"].get("start", {}).get("toolUse")
+            if tool:
+                print(f"\n  [tool: {tool.get('name')}]", flush=True)
+        elif "contentBlockDelta" in event:
             delta = event["contentBlockDelta"].get("delta", {})
             if "text" in delta:
                 print(delta["text"], end="", flush=True)
@@ -49,11 +55,23 @@ def main() -> None:
     client = boto3.client("bedrock-agentcore", region_name=region)
 
     # The session id must be >= 33 chars; reuse it across turns so the harness
-    # loads the prior history from memory before reasoning.
+    # loads the prior history (and the search results) from memory before
+    # reasoning on the follow-up.
     session_id = f"{uuid.uuid4().hex}{uuid.uuid4().hex}"
 
-    stream(client, harness_arn, session_id, "Hi! My name is Ikuma. Please remember it.")
-    stream(client, harness_arn, session_id, "What is my name?")
+    stream(
+        client,
+        harness_arn,
+        session_id,
+        "Use web search to find the latest stable Terraform release version, "
+        "then answer with the version number and cite the source URL.",
+    )
+    stream(
+        client,
+        harness_arn,
+        session_id,
+        "Without searching again, what version did you just report?",
+    )
 
 
 if __name__ == "__main__":

--- a/stacks/agentcore-harness/justfile
+++ b/stacks/agentcore-harness/justfile
@@ -10,12 +10,13 @@ default:
 init:
     {{tf}} init
 
-# Provision the execution role + harness (managed memory auto-provisions).
+# Provision the execution role, Gateway + web-search target, and harness
+# (managed memory auto-provisions).
 deploy: init
     {{tf}} apply
 
-# Stream two turns through the deployed harness, reusing one session id to show
-# managed short-term memory carrying the conversation.
+# Stream two turns through the deployed harness: the first triggers the
+# Gateway-backed web_search tool, the second is answered from managed memory.
 invoke:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/stacks/agentcore-harness/terraform/gateway.tf
+++ b/stacks/agentcore-harness/terraform/gateway.tf
@@ -1,0 +1,80 @@
+# --- Gateway: the web-search tool surface for the harness ---------------------
+# The harness reaches managed Web Search through an AgentCore Gateway. The
+# built-in "web-search" connector is attached as a Gateway target (see
+# gateway_target.tf); referencing the gateway ARN from the harness `tools` block
+# (harness.tf) makes every tool on it available to the agent.
+#
+# Inbound auth is AWS_IAM: callers are authorized by their IAM identity, so no
+# Cognito user pool or JWT is involved. The harness signs its Gateway calls with
+# SigV4 using its own execution role (the default `agentcore_gateway` outbound
+# auth), which therefore just needs `bedrock-agentcore:InvokeGateway` (iam.tf).
+# Contrast stacks/agentcore-web-search, where a Strands runtime reaches the same
+# Gateway over MCP and needs a CUSTOM_JWT authorizer + AgentCore Identity to mint
+# bearer tokens — the harness drops that whole layer because AWS runs the loop
+# and signs with IAM natively.
+
+# Service role the Gateway assumes to reach the AWS-managed Web Search backend.
+# Web Search needs InvokeGateway + InvokeWebSearch (checked per request against
+# the service-owned tool ARN).
+data "aws_iam_policy_document" "gateway_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:gateway/*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "gateway" {
+  name               = "${var.name_prefix}-gateway-role"
+  assume_role_policy = data.aws_iam_policy_document.gateway_assume.json
+}
+
+data "aws_iam_policy_document" "gateway" {
+  statement {
+    sid       = "InvokeGateway"
+    effect    = "Allow"
+    actions   = ["bedrock-agentcore:InvokeGateway"]
+    resources = ["arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:gateway/*"]
+  }
+
+  statement {
+    sid       = "InvokeWebSearch"
+    effect    = "Allow"
+    actions   = ["bedrock-agentcore:InvokeWebSearch"]
+    resources = ["arn:aws:bedrock-agentcore:${local.region}:aws:tool/web-search.v1"]
+  }
+}
+
+resource "aws_iam_role_policy" "gateway" {
+  name   = "web-search"
+  role   = aws_iam_role.gateway.id
+  policy = data.aws_iam_policy_document.gateway.json
+}
+
+# AWS_IAM inbound auth needs no authorizer_configuration block — that is only
+# required for CUSTOM_JWT. Callers are authorized purely by IAM
+# (bedrock-agentcore:InvokeGateway scoped to this gateway in iam.tf).
+resource "aws_bedrockagentcore_gateway" "this" {
+  name            = var.name_prefix
+  role_arn        = aws_iam_role.gateway.arn
+  protocol_type   = "MCP"
+  authorizer_type = "AWS_IAM"
+
+  depends_on = [aws_iam_role_policy.gateway]
+}

--- a/stacks/agentcore-harness/terraform/gateway_target.tf
+++ b/stacks/agentcore-harness/terraform/gateway_target.tf
@@ -1,0 +1,32 @@
+# The Web Search target uses the built-in "web-search" connector. Neither the
+# native aws_bedrockagentcore_gateway_target resource nor the bundled aws CLI
+# model the `connector` target type yet (only lambda / api_gateway / mcp_server /
+# open_api_schema / smithy_model), so we create it with a small boto3 helper run
+# through `uv run --script` (a self-contained PEP 723 script whose pinned boto3
+# is new enough to know the `connector` shape). Everything else is native
+# Terraform / awscc.
+#
+# To add a domain denylist, append `--exclude-domain blocked-1.com` (repeatable)
+# to the create command below; see web_search_target.py.
+
+resource "terraform_data" "web_search_target" {
+  triggers_replace = [aws_bedrockagentcore_gateway.this.gateway_id]
+
+  # Carried in `input` so the destroy-time provisioner can reach them via `self`
+  # (other resources, vars, and locals are not available during destroy).
+  input = {
+    region     = local.region
+    gateway_id = aws_bedrockagentcore_gateway.this.gateway_id
+    name       = "web-search-tool"
+    script     = abspath("${path.module}/../web_search_target.py")
+  }
+
+  provisioner "local-exec" {
+    command = "env -u VIRTUAL_ENV uv run --script ${self.input.script} create --region ${self.input.region} --gateway-id ${self.input.gateway_id} --name ${self.input.name}"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "env -u VIRTUAL_ENV uv run --script ${self.input.script} delete --region ${self.input.region} --gateway-id ${self.input.gateway_id} --name ${self.input.name}"
+  }
+}

--- a/stacks/agentcore-harness/terraform/harness.tf
+++ b/stacks/agentcore-harness/terraform/harness.tf
@@ -30,15 +30,38 @@ resource "awscc_bedrockagentcore_harness" "this" {
   model = {
     bedrock_model_config = {
       model_id = var.model_id
-      # Selects the protocol and Bedrock endpoint: chat_completions / responses
-      # route through the OpenAI-compatible bedrock-mantle endpoint (Kimi K2.5),
-      # converse_stream uses the native bedrock-runtime Converse API.
+      # Selects the protocol and Bedrock endpoint: converse_stream uses the
+      # native bedrock-runtime Converse API (its tool IDs satisfy the harness's
+      # tool-result schema, so it is required for the web_search tool below);
+      # chat_completions / responses route through the OpenAI-compatible
+      # bedrock-mantle endpoint, which is tool-free here (those models emit
+      # OpenAI-style tool IDs the harness rejects).
       api_format = var.api_format
     }
   }
 
+  # Web search as a governed tool surface. Reference the Gateway by ARN and every
+  # tool configured on it — here just the built-in "web-search" connector
+  # (gateway_target.tf) — becomes callable by the agent. `outbound_auth` is
+  # omitted, so it defaults to AWS IAM (SigV4) signed with this harness's
+  # execution role; that role's bedrock-agentcore:InvokeGateway grant (iam.tf)
+  # satisfies the Gateway's AWS_IAM inbound authorizer. `allowed_tools` is left
+  # unset, so all tools (the built-in shell + file_operations and this gateway's
+  # tools) stay available.
+  tools = [{
+    name = "web_search"
+    type = "agentcore_gateway"
+    config = {
+      agent_core_gateway = {
+        gateway_arn = aws_bedrockagentcore_gateway.this.gateway_arn
+      }
+    }
+  }]
+
   max_iterations  = var.max_iterations
   timeout_seconds = var.timeout_seconds
 
-  depends_on = [time_sleep.role_propagation]
+  # The connector target must be READY before the harness enumerates the
+  # gateway's tools, so order it ahead of (and the role delay alongside) create.
+  depends_on = [time_sleep.role_propagation, terraform_data.web_search_target]
 }

--- a/stacks/agentcore-harness/terraform/iam.tf
+++ b/stacks/agentcore-harness/terraform/iam.tf
@@ -122,6 +122,16 @@ data "aws_iam_policy_document" "harness" {
     ]
     resources = ["arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:memory/harness_${var.harness_name}_*"]
   }
+
+  # The harness signs its Gateway calls with SigV4 using THIS role (the default
+  # `agentcore_gateway` outbound auth), and the Gateway's AWS_IAM inbound
+  # authorizer checks InvokeGateway. Scoped to the one gateway we attach.
+  statement {
+    sid       = "InvokeGateway"
+    effect    = "Allow"
+    actions   = ["bedrock-agentcore:InvokeGateway"]
+    resources = [aws_bedrockagentcore_gateway.this.gateway_arn]
+  }
 }
 
 resource "aws_iam_role_policy" "harness" {

--- a/stacks/agentcore-harness/terraform/outputs.tf
+++ b/stacks/agentcore-harness/terraform/outputs.tf
@@ -13,6 +13,16 @@ output "harness_status" {
   value       = awscc_bedrockagentcore_harness.this.status
 }
 
+output "gateway_id" {
+  description = "Identifier of the AgentCore Gateway backing the web-search tool."
+  value       = aws_bedrockagentcore_gateway.this.gateway_id
+}
+
+output "gateway_arn" {
+  description = "ARN of the AgentCore Gateway attached to the harness as the web-search tool."
+  value       = aws_bedrockagentcore_gateway.this.gateway_arn
+}
+
 output "invoke_command" {
   description = "Copy-paste command to stream two turns through the harness."
   value       = "uv run --script invoke.py ${awscc_bedrockagentcore_harness.this.arn}"

--- a/stacks/agentcore-harness/terraform/variables.tf
+++ b/stacks/agentcore-harness/terraform/variables.tf
@@ -16,15 +16,15 @@ variable "harness_name" {
 }
 
 variable "model_id" {
-  description = "Default Bedrock model the harness reasons with. Kimi K2.5 is available in-region in us-east-1 (no geo/global inference profile), so the plain model ID is used. Override per InvokeHarness call to swap models mid-session."
+  description = "Default Bedrock model the harness reasons with. Defaults to Claude Sonnet 4.6 via its us geo inference profile (Sonnet 4.6 has no in-region profile in us-east-1). A native Converse tool-caller is required for the web_search tool: models served through the bedrock-mantle endpoint (e.g. moonshotai.kimi-k2.5) emit OpenAI-style tool IDs the harness rejects, so they only work tool-free. Override per InvokeHarness call to swap models mid-session."
   type        = string
-  default     = "moonshotai.kimi-k2.5"
+  default     = "us.anthropic.claude-sonnet-4-6"
 }
 
 variable "api_format" {
-  description = "Bedrock API protocol + endpoint the harness calls: 'converse_stream' (Converse on bedrock-runtime, the default for most models), or 'responses'/'chat_completions' (OpenAI-compatible, served by the bedrock-mantle endpoint). Kimi K2.5 is served via Mantle."
+  description = "Bedrock API protocol + endpoint the harness calls: 'converse_stream' (Converse on bedrock-runtime — required here for tool use, since its tool IDs satisfy the harness schema), or 'responses'/'chat_completions' (OpenAI-compatible, served by the bedrock-mantle endpoint; usable only without tools)."
   type        = string
-  default     = "chat_completions"
+  default     = "converse_stream"
 
   validation {
     condition     = contains(["converse_stream", "responses", "chat_completions"], var.api_format)

--- a/stacks/agentcore-harness/web_search_target.py
+++ b/stacks/agentcore-harness/web_search_target.py
@@ -1,0 +1,138 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["boto3>=1.43"]
+# ///
+# pyright: basic
+"""Create or delete the Gateway's built-in "web-search" connector target.
+
+Neither the native ``aws_bedrockagentcore_gateway_target`` resource nor the
+bundled ``aws`` CLI model the ``connector`` target type yet (only lambda /
+api_gateway / mcp_server / open_api_schema / smithy_model), so Terraform shells
+out to this helper. It runs as a self-contained PEP 723 script via
+``uv run --script``, which builds an isolated env from the inline boto3 pin
+above — new enough to know the ``connector`` shape.
+
+Usage:
+    uv run --script web_search_target.py create --region us-east-1 --gateway-id <id>
+    uv run --script web_search_target.py delete --region us-east-1 --gateway-id <id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import boto3
+
+CONNECTOR_ID = "web-search"
+TOOL_NAME = "WebSearch"
+_TERMINAL_OK = "READY"
+_TERMINAL_FAIL = {"FAILED", "CREATE_PENDING_AUTH", "UPDATE_UNSUCCESSFUL"}
+
+
+def _client(region: str):
+    return boto3.client("bedrock-agentcore-control", region_name=region)
+
+
+def _find_target_id(client, gateway_id: str, name: str) -> str | None:
+    next_token: str | None = None
+    while True:
+        kwargs = {"gatewayIdentifier": gateway_id}
+        if next_token:
+            kwargs["nextToken"] = next_token
+        resp = client.list_gateway_targets(**kwargs)
+        for item in resp.get("items", []):
+            if item.get("name") == name:
+                return item.get("targetId")
+        next_token = resp.get("nextToken")
+        if not next_token:
+            return None
+
+
+def _wait_ready(client, gateway_id: str, target_id: str, timeout: int = 180) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        resp = client.get_gateway_target(
+            gatewayIdentifier=gateway_id, targetId=target_id
+        )
+        status = resp.get("status")
+        if status == _TERMINAL_OK:
+            print(f"target {target_id} is READY")
+            return
+        if status in _TERMINAL_FAIL:
+            reasons = resp.get("statusReasons") or []
+            raise SystemExit(
+                f"target {target_id} did not become READY: {status} {reasons}"
+            )
+        if time.monotonic() > deadline:
+            raise SystemExit(
+                f"timed out after {timeout}s waiting for {target_id} (last status: {status})"
+            )
+        time.sleep(3)
+
+
+def create(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    target_id = _find_target_id(client, args.gateway_id, args.name)
+    if target_id:
+        print(f"target {args.name!r} already exists ({target_id}); ensuring READY")
+    else:
+        parameter_values: dict[str, object] = {}
+        if args.exclude_domain:
+            parameter_values["domainFilter"] = {"exclude": args.exclude_domain}
+        resp = client.create_gateway_target(
+            gatewayIdentifier=args.gateway_id,
+            name=args.name,
+            targetConfiguration={
+                "mcp": {
+                    "connector": {
+                        "source": {"connectorId": CONNECTOR_ID},
+                        "configurations": [
+                            {"name": TOOL_NAME, "parameterValues": parameter_values}
+                        ],
+                    }
+                }
+            },
+            credentialProviderConfigurations=[
+                {"credentialProviderType": "GATEWAY_IAM_ROLE"}
+            ],
+        )
+        target_id = resp["targetId"]
+        print(f"created target {args.name!r} ({target_id})")
+    _wait_ready(client, args.gateway_id, target_id)
+
+
+def delete(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    target_id = _find_target_id(client, args.gateway_id, args.name)
+    if not target_id:
+        print(f"target {args.name!r} not found; nothing to delete")
+        return
+    client.delete_gateway_target(gatewayIdentifier=args.gateway_id, targetId=target_id)
+    print(f"deleted target {args.name!r} ({target_id})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Manage the web-search gateway target."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--region", required=True)
+    common.add_argument("--gateway-id", required=True)
+    common.add_argument("--name", default="web-search-tool")
+
+    create_parser = sub.add_parser("create", parents=[common])
+    create_parser.add_argument("--exclude-domain", action="append", default=[])
+    create_parser.set_defaults(func=create)
+
+    delete_parser = sub.add_parser("delete", parents=[common])
+    delete_parser.set_defaults(func=delete)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds **managed Web Search** to the `agentcore-harness` example as a declarative, IaC-native tool.

The harness `agentcore_gateway` tool points at an **AgentCore Gateway** that hosts the built-in `web-search` connector target:

```txt
harness ─ agentcore_gateway tool ─ SigV4 (execution role) ▶ Gateway (AWS_IAM inbound)
                                                              └─ connector "web-search"
                                                                   │ GATEWAY_IAM_ROLE (SigV4)
                                                                   ▼  AWS-managed Web Search
```

## Why it's simpler than `agentcore-web-search`

Because the harness signs Gateway calls with **SigV4 using its own execution role**, the Gateway uses an **`AWS_IAM` inbound authorizer** — so this drops the entire **Cognito user pool + AgentCore Identity OAuth2** layer the Runtime example needs. The whole inbound/outbound auth collapses to two IAM grants:

- execution role → `bedrock-agentcore:InvokeGateway` (inbound)
- gateway service role → `InvokeGateway` + `InvokeWebSearch` (outbound to the managed backend)

## Notable change: default model

Switched the default model to **Claude Sonnet 4.6** on `converse_stream`. Harness **tool use requires native Converse tool IDs**; Bedrock Mantle models (`chat_completions`/`responses`, e.g. Kimi K2.5 — the previous default) emit OpenAI-style tool IDs (`functions.<name>:0`) that the harness's tool-result schema rejects (`^[a-zA-Z0-9_-]+$`), so they only work **tool-free**. Kimi stays available as a var override for a tool-free harness.

## Connector target

The `web-search` connector target type still isn't modeled by the `aws`/`awscc` providers (nor is the simpler native `agentcore_web_search` harness tool type in the CloudFormation schema), so the target is created by a self-contained PEP 723 boto3 helper (`web_search_target.py`) run from a `terraform_data` provisioner. Everything else is native Terraform/awscc.

## Files

- New: `terraform/gateway.tf`, `terraform/gateway_target.tf`, `web_search_target.py`
- Edited: `terraform/harness.tf` (tool), `terraform/iam.tf` (InvokeGateway grant), `terraform/variables.tf` (model default), `terraform/outputs.tf`, `invoke.py`, `justfile`, READMEs

## Verification

Deployed live to us-east-1 (`terraform apply` clean, `validate`/`fmt`/`ruff` pass, `plan` shows no drift). `just invoke`:

- **Turn 1** called `web-search-tool___WebSearch` and answered with cited source URLs.
- **Turn 2** ("Without searching again…") answered **from managed memory** — no second search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)