### PR TITLE
feat(agentcore): set idle runtime session timeout

### DIFF
--- a/stacks/agentcore-harness/terraform/harness.tf
+++ b/stacks/agentcore-harness/terraform/harness.tf
@@ -61,6 +61,18 @@ resource "awscc_bedrockagentcore_harness" "this" {
   max_iterations  = var.max_iterations
   timeout_seconds = var.timeout_seconds
 
+  # Tune the managed runtime that backs the harness. `agent_core_runtime_environment`
+  # is the only environment provider; its `agent_runtime_*` fields are read-only (the
+  # runtime is auto-provisioned), so we set only the lifecycle knobs. Omitting this
+  # block leaves the platform default idle timeout of 900s. Valid range 60-28800s.
+  environment = {
+    agent_core_runtime_environment = {
+      lifecycle_configuration = {
+        idle_runtime_session_timeout = 60
+      }
+    }
+  }
+
   # The connector target must be READY before the harness enumerates the
   # gateway's tools, so order it ahead of (and the role delay alongside) create.
   depends_on = [time_sleep.role_propagation, terraform_data.web_search_target]

--- a/stacks/agentcore-web-search/terraform/runtime.tf
+++ b/stacks/agentcore-web-search/terraform/runtime.tf
@@ -147,6 +147,10 @@ resource "aws_bedrockagentcore_agent_runtime" "this" {
     server_protocol = "HTTP"
   }
 
+  lifecycle_configuration {
+    idle_runtime_session_timeout = 60
+  }
+
   environment_variables = merge(
     {
       GATEWAY_URL = aws_bedrockagentcore_gateway.this.gateway_url


### PR DESCRIPTION
## What

Sets `idle_runtime_session_timeout = 60` on both AgentCore stacks so idle microVM sessions are reclaimed sooner than the **900s** platform default.

## Changes

- **`stacks/agentcore-web-search/terraform/runtime.tf`** — top-level `lifecycle_configuration` block on `aws_bedrockagentcore_agent_runtime` (`hashicorp/aws`).
- **`stacks/agentcore-harness/terraform/harness.tf`** — nested under `environment.agent_core_runtime_environment.lifecycle_configuration` on the `awscc_bedrockagentcore_harness` resource. The harness has no top-level lifecycle block; the timeout tunes the managed runtime that backs it. `agent_runtime_*` fields there stay read-only / auto-provisioned.

## Notes

- Valid range is **60–28800s**; `max_lifetime` is available in the same block if a hard cap is wanted later.
- Per the CloudFormation schema both are in-place updates (no interruption / no replacement), even though `environment` was previously omitted on the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)