### PR TITLE
Add AWS Lambda MicroVMs code-exec sandbox example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ members = [
     "python/python-strands-agents",
     "python/python-llama-index",
     "stacks/agentcore-web-search/agent",
+    "stacks/aws-lambda-microvms/image",
+    "stacks/aws-lambda-microvms/control",
 ]
 
 [dependency-groups]
@@ -34,6 +36,7 @@ testpaths = [
     "python/python-strands-agents",
     "python/python-llama-index",
     "stacks/agentcore-web-search/agent/tests",
+    "stacks/aws-lambda-microvms/image/tests",
 ]
 markers = [
     "live: hits real services, costs money, requires secrets",

--- a/stacks/aws-lambda-microvms/.gitignore
+++ b/stacks/aws-lambda-microvms/.gitignore
@@ -1,0 +1,11 @@
+# Pointer to the most recently run MicroVM, written by the control CLI.
+.microvm-last.json
+
+# Local image artifacts.
+*.zip
+
+# Terraform local state / providers.
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl

--- a/stacks/aws-lambda-microvms/README.md
+++ b/stacks/aws-lambda-microvms/README.md
@@ -1,0 +1,162 @@
+# AWS Lambda MicroVMs
+
+A runnable example of [AWS Lambda MicroVMs][announce] — a serverless compute
+primitive (distinct from Lambda **Functions**) for running untrusted user- or
+AI-generated code in VM-isolated, stateful sandboxes that launch in ~1s, keep
+memory/disk state across a session, and suspend to low idle cost. It reuses the
+same Firecracker virtualization that powers Lambda Functions, but exposes direct
+lifecycle control, snapshot suspend/resume, long sessions (up to 8h), arbitrary
+ports/protocols, and customer-provided images.
+
+This stack builds a **code-execution sandbox**: a MicroVM image that accepts
+Python over HTTP and runs it in a persistent session. The session's variables
+live in memory, so they survive **suspend/resume** — the headline MicroVMs
+capability.
+
+```txt
+  operator (control CLI, boto3)
+    │  create-microvm-image  ── zip(Dockerfile+src) ─▶ S3 ─▶ Lambda builds image
+    │                                                        (runs Dockerfile,
+    │                                                         calls /ready, snapshots)
+    │  run-microvm ───────────────────────────────────▶ MicroVM  (resumes snapshot)
+    │  create-microvm-auth-token ─▶ JWE token                │
+    │                                                        │
+    ▼  HTTPS  https://<id>.lambda-microvm.<region>.on.aws    │
+       POST /exec   X-aws-proxy-auth: <token>  ──▶ :8080 ── sandbox app
+                                                   :9000 ── lifecycle hooks
+                                                            /run /resume
+                                                            /suspend /terminate
+    │  suspend-microvm  (memory+disk snapshot; session state preserved)
+    │  resume-microvm   (state restored; /resume hook reseeds ephemerals)
+    ▼  terminate-microvm
+```
+
+## Layout
+
+| Path         | What                                                                                                                                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `image/`     | uv-workspace member — the sandbox baked into the MicroVM image. `/exec` on the 8080 traffic port; the four lifecycle hooks on the 9000 control port. `Dockerfile` is built **by Lambda**, not locally. |
+| `control/`   | uv-workspace member — the boto3 + httpx operator CLI (`microvm-control`) driving the imperative lifecycle.                                                                                             |
+| `terraform/` | supporting infra only: S3 artifact bucket + build/execution IAM roles. The lifecycle itself is imperative and lives in the CLI, not in IaC.                                                            |
+| `justfile`   | wires terraform outputs into the CLI: `infra` → `build` → `run`/`demo`.                                                                                                                                |
+
+## Why no Terraform for the MicroVM itself
+
+`run`/`suspend`/`resume`/`terminate` are control-plane _operations_, not
+declarative state, so they don't map onto Terraform. Terraform here only
+provisions the durable supporting resources (bucket, roles); everything with a
+lifecycle is driven through `microvm-control` (boto3 `lambda-microvms`).
+
+## Prerequisites
+
+- `terraform`, `just`, and `uv`. **No Docker** — the image is built server-side
+  by Lambda. (The `aws` CLI is optional; the control plane is driven through
+  boto3, and older CLI builds don't yet ship the `lambda-microvms` command.)
+- AWS credentials in a MicroVMs Region (default `us-east-1`).
+- `boto3`/`botocore` **≥ 1.43.36** (the first release with the `lambda-microvms`
+  client; pinned in `control/pyproject.toml`). Verify:
+  `uv run --package microvm-control python -c "import boto3; print('lambda-microvms' in boto3.session.Session().get_available_services())"`
+- Operator IAM permissions — see [Operator permissions](#operator-permissions).
+
+> [!NOTE]
+> Verified end-to-end on 2026-06-28 in `us-east-1`: `infra` → `build` → `demo`
+> (run → exec → suspend → resume → exec → terminate) with `counter` surviving the
+> snapshot at `105`.
+
+## Deploy and run
+
+```sh
+cd stacks/aws-lambda-microvms
+
+just init          # terraform init
+just infra         # S3 bucket + build/execution roles
+just build         # zip image/ -> S3 -> create-microvm-image -> wait for CREATED
+just demo          # run -> exec -> suspend -> resume -> exec -> terminate
+```
+
+`just demo` proves the point: it sets `counter = 100`, increments it, **suspends
+and resumes** the MicroVM, then reads `counter` back — still `105`, because the
+session lives in the snapshotted memory.
+
+Step through it manually instead:
+
+```sh
+just run                       # prints microvmId + endpoint (cached in .microvm-last.json)
+just exec code='x = 21'
+just exec code='print(x * 2)'  # -> 42  (state from the previous call)
+just suspend
+just resume
+just exec code='print(x * 2)'  # -> 42  (survived the snapshot)
+just terminate
+just destroy                   # tear down the bucket + roles
+```
+
+## How it works
+
+- **Image build = snapshot.** `create-microvm-image` uploads `image/` (the
+  Dockerfile plus `src/`) to S3; Lambda runs the Dockerfile, starts the app, polls
+  the `/ready` hook, and captures a Firecracker snapshot of the initialized memory
+  and disk. Every `run-microvm` resumes from that snapshot (hence ~1s launches).
+- **Two ports.** The sandbox serves traffic on `8080` (the default routing
+  target) and the lifecycle hooks on `9000` (declared as `hooks.port` at image
+  creation). Both bind `0.0.0.0`; Lambda reaches the hook port from outside the
+  guest. See `image/src/microvm_sandbox/main.py`.
+- **Lifecycle hooks** (`image/src/microvm_sandbox/hooks.py`), all `POST` under
+  `/aws/lambda-microvms/runtime/v1`:
+  - `/ready` — build-time gate; 503 until the app is up, then 200.
+  - `/run` — fires once per launch _before_ traffic is forwarded; starts a fresh
+    session (every MicroVM resumes the **shared** build snapshot, so per-session
+    state must be reset). Receives `{"microvmId", "runHookPayload"}`.
+  - `/resume` — fires on SUSPENDED→RUNNING; the VM stays SUSPENDED until it
+    returns 200. Session state is kept; this is where a real app reseeds RNGs and
+    re-opens connections that shouldn't outlive a snapshot.
+  - `/suspend`, `/terminate` — checkpoint / clean up. Made idempotent (Lambda may
+    retry them).
+- **Data plane.** `run-microvm` returns the endpoint _without_ a scheme. Prefix
+  `https://`, send the `create-microvm-auth-token` value as the
+  `X-aws-proxy-auth` header (no unauthenticated access), and optionally
+  `X-aws-proxy-port` to target a non-default port.
+
+## Operator permissions
+
+The credentials that run `microvm-control` (your own, not the Lambda roles) need,
+in addition to the `lambda-microvms` control-plane actions:
+
+- `iam:PassRole` on the build role (passed to `create-microvm-image`) and the
+  execution role (passed to `run-microvm`).
+- `lambda:PassNetworkConnector` — required on **every** `run-microvm` call, even
+  with no explicit connectors (defaults are passed at run time).
+- `s3:PutObject` on the artifact bucket (the CLI uploads the zip).
+
+> [!WARNING]
+> **Verify the control-plane action prefix before locking down a policy.** AWS
+> primary docs did not confirm whether the actions are `lambda:RunMicrovm…` or
+> `lambda-microvms:RunMicrovm…` (CloudTrail logs them under `lambda:`). Check the
+> AWS Service Authorization Reference and scope your operator policy accordingly.
+> This example does **not** ship a guessed caller policy.
+
+## Notes from the live run
+
+- **Identifiers are not uniform.** MicroVM ops (`get`/`suspend`/`resume`/
+  `terminate`/`create-microvm-auth-token`) accept the bare `microvmId`, but the
+  **image** ops (`get-microvm-image`) require the **full image ARN** —
+  `arn:aws:lambda:<region>:<acct>:microvm-image:<name>`, not the bare name. The
+  control CLI resolves a name to its ARN via `list-microvm-images`.
+- **`base_image_arn`** — confirmed `arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1`
+  via `list-managed-microvm-images`. Re-check per Region; the suffix can change.
+- **`run-microvm` auto-attaches default connectors** (`HTTP_INGRESS`,
+  `INTERNET_EGRESS`), which is why the caller needs `lambda:PassNetworkConnector`.
+
+## Caveats / still to verify
+
+- **Operator action prefix** — see the warning above; tested here only with
+  `AdministratorAccess`, so a least-privilege caller policy is still unverified.
+- **`runHookPayload`** — AWS docs self-conflict on the cap (4096 vs 16384 bytes);
+  the CLI assumes the safe ≤4096.
+- **Regions** — GA in `us-east-1`, `us-east-2`, `us-west-2`, `ap-northeast-1`,
+  `eu-west-1`.
+- **Snapshot/OpenSSL** — apps that do TLS or generate unique secrets at init must
+  reseed in `/run` and `/resume`; the AWS-provided `public.ecr.aws/lambda/microvms`
+  base image carries snapshot-safe fixes if you hit this.
+
+[announce]: https://aws.amazon.com/about-aws/whats-new/2026/06/aws-lambda-microvms/

--- a/stacks/aws-lambda-microvms/control/pyproject.toml
+++ b/stacks/aws-lambda-microvms/control/pyproject.toml
@@ -1,0 +1,20 @@
+# A member of the repo-root uv workspace. Dev tooling (ruff/pyright/pytest) and
+# the lockfile live at the workspace root; this file declares only the operator
+# CLI's runtime dependencies.
+[project]
+name = "microvm-control"
+version = "0.1.0"
+description = "Operator CLI for the AWS Lambda MicroVMs code-exec sandbox example"
+requires-python = ">=3.13"
+dependencies = [
+    # 1.43.36 is the first botocore/boto3 release with the lambda-microvms client.
+    "boto3>=1.43.36",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+microvm-control = "microvm_control.cli:main"
+
+[build-system]
+requires = ["uv_build>=0.7.0,<0.9.0"]
+build-backend = "uv_build"

--- a/stacks/aws-lambda-microvms/control/src/microvm_control/__init__.py
+++ b/stacks/aws-lambda-microvms/control/src/microvm_control/__init__.py
@@ -1,0 +1,7 @@
+"""Operator CLI for the AWS Lambda MicroVMs code-exec sandbox example.
+
+Drives the imperative MicroVM lifecycle that does not map cleanly to declarative
+IaC: package + build the image, run a MicroVM, mint a JWE auth token, call the
+sandbox over its HTTPS endpoint, and suspend/resume/terminate. See
+``microvm_control.cli`` for the command surface, or run ``microvm-control --help``.
+"""

--- a/stacks/aws-lambda-microvms/control/src/microvm_control/__main__.py
+++ b/stacks/aws-lambda-microvms/control/src/microvm_control/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/stacks/aws-lambda-microvms/control/src/microvm_control/cli.py
+++ b/stacks/aws-lambda-microvms/control/src/microvm_control/cli.py
@@ -1,0 +1,411 @@
+# boto3 ships only partial type information for its dynamic clients, so this
+# module opts down to basic type checking (the repo convention for boto3 code).
+# pyright: basic
+"""Command-line driver for the Lambda MicroVMs lifecycle.
+
+Subcommands map onto the ``lambda-microvms`` control plane plus the MicroVM's
+data-plane HTTPS endpoint:
+
+    build      zip image/ -> S3 -> create-microvm-image, wait for CREATED
+    run        run-microvm (returns a microvmId + endpoint)
+    status     get-microvm
+    wait       poll get-microvm until a target state
+    token      create-microvm-auth-token
+    exec       POST /exec to the running sandbox
+    suspend    suspend-microvm
+    resume     resume-microvm
+    terminate  terminate-microvm
+    demo       run -> exec -> suspend -> resume -> exec -> terminate end to end
+
+The id of the most recently run MicroVM is cached in ./.microvm-last.json, so
+most subcommands default to it when --microvm-id is omitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import boto3
+import httpx
+
+SERVICE = "lambda-microvms"
+DEFAULT_REGION = os.environ.get("AWS_REGION", "us-east-1")
+DEFAULT_IMAGE_DIR = "stacks/aws-lambda-microvms/image"
+CONTROL_PORT = 9000  # must match hooks.port baked into the image
+TRAFFIC_PORT = 8080  # default MicroVM routing target
+STATE_FILE = Path(".microvm-last.json")
+
+# Terminal states we poll toward.
+RUNNING = "RUNNING"
+SUSPENDED = "SUSPENDED"
+TERMINATED = "TERMINATED"
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _client(region: str) -> Any:
+    return boto3.client(SERVICE, region_name=region)
+
+
+def _print(obj: Any) -> None:
+    print(json.dumps(obj, indent=2, default=str))
+
+
+def _save_last(microvm_id: str, region: str) -> None:
+    STATE_FILE.write_text(json.dumps({"microvmId": microvm_id, "region": region}))
+
+
+def _resolve_id(microvm_id: str | None) -> str:
+    if microvm_id:
+        return microvm_id
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())["microvmId"]
+    sys.exit("no --microvm-id given and no ./.microvm-last.json to fall back to")
+
+
+def _zip_image(image_dir: Path) -> bytes:
+    """Zip the Dockerfile (at the root) and src/ — the image build context."""
+    dockerfile = image_dir / "Dockerfile"
+    src = image_dir / "src"
+    if not dockerfile.is_file():
+        sys.exit(f"no Dockerfile in {image_dir}")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.write(dockerfile, "Dockerfile")
+        for path in sorted(src.rglob("*")):
+            if path.is_file() and "__pycache__" not in path.parts:
+                archive.write(path, str(path.relative_to(image_dir)))
+    return buffer.getvalue()
+
+
+def _poll_microvm(
+    client: Any, microvm_id: str, target: str, timeout: int = 300
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while True:
+        response = client.get_microvm(microvmIdentifier=microvm_id)
+        state = response.get("state")
+        print(f"  microvm {microvm_id}: {state}")
+        if state == target:
+            return response
+        if state == TERMINATED and target != TERMINATED:
+            sys.exit(f"microvm reached {state} (reason: {response.get('stateReason')})")
+        if time.monotonic() > deadline:
+            sys.exit(f"timed out waiting for {target} (last state: {state})")
+        time.sleep(3)
+
+
+def _endpoint(client: Any, microvm_id: str) -> str:
+    endpoint = client.get_microvm(microvmIdentifier=microvm_id).get("endpoint")
+    if not endpoint:
+        sys.exit(f"microvm {microvm_id} has no endpoint yet")
+    return f"https://{endpoint}"
+
+
+def _mint_token(client: Any, microvm_id: str, port: int, minutes: int) -> str:
+    response = client.create_microvm_auth_token(
+        microvmIdentifier=microvm_id,
+        expirationInMinutes=minutes,
+        allowedPorts=[{"port": port}],
+    )
+    return response["authToken"]["X-aws-proxy-auth"]
+
+
+def _post_exec(base_url: str, token: str, code: str, port: int) -> dict[str, Any]:
+    response = httpx.post(
+        f"{base_url}/exec",
+        headers={"X-aws-proxy-auth": token, "X-aws-proxy-port": str(port)},
+        json={"code": code},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _resolve_image(client: Any, image: str) -> str:
+    """Return the image ARN. The get/run ops want a full ARN, not the bare name,
+    so a name is looked up in list-microvm-images."""
+    if image.startswith("arn:"):
+        return image
+    for item in client.list_microvm_images().get("items", []):
+        if item.get("name") == image:
+            return item["imageArn"]
+    sys.exit(f"no microvm image named {image!r}")
+
+
+def _wait_image(client: Any, image_arn: str, timeout: int = 1800) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        state = client.get_microvm_image(imageIdentifier=image_arn).get("state")
+        print(f"  image: {state}")
+        if state and "FAILED" in state:
+            sys.exit(f"image build failed ({state})")
+        if state not in (None, "CREATING", "PENDING", "BUILDING"):
+            return
+        if time.monotonic() > deadline:
+            sys.exit("timed out waiting for image build")
+        time.sleep(10)
+
+
+# --------------------------------------------------------------------------- #
+# commands
+# --------------------------------------------------------------------------- #
+def cmd_build(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    image_dir = Path(args.image_dir)
+    payload = _zip_image(image_dir)
+
+    s3 = boto3.client("s3", region_name=args.region)
+    key = f"{args.name}.zip"
+    print(f"uploading {len(payload)} bytes to s3://{args.artifact_bucket}/{key}")
+    s3.put_object(Bucket=args.artifact_bucket, Key=key, Body=payload)
+
+    print(f"creating microvm image {args.name!r}")
+    response = client.create_microvm_image(
+        name=args.name,
+        baseImageArn=args.base_image_arn,
+        buildRoleArn=args.build_role_arn,
+        codeArtifact={"uri": f"s3://{args.artifact_bucket}/{key}"},
+        cpuConfigurations=[{"architecture": "ARM_64"}],
+        hooks={
+            "port": CONTROL_PORT,
+            "microvmImageHooks": {"ready": "ENABLED", "readyTimeoutInSeconds": 30},
+            "microvmHooks": {
+                "run": "ENABLED",
+                "runTimeoutInSeconds": 10,
+                "resume": "ENABLED",
+                "resumeTimeoutInSeconds": 10,
+                "suspend": "ENABLED",
+                "suspendTimeoutInSeconds": 10,
+                "terminate": "ENABLED",
+                "terminateTimeoutInSeconds": 10,
+            },
+        },
+    )
+    image_arn = response.get("imageArn") or _resolve_image(client, args.name)
+
+    print(
+        f"waiting for image build (logs: CloudWatch /aws/lambda/microvms/{args.name})"
+    )
+    _wait_image(client, image_arn)
+    print(f"image is ready — run it with: microvm-control run --image {image_arn}")
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    request: dict[str, Any] = {
+        "imageIdentifier": _resolve_image(client, args.image),
+        "idlePolicy": {
+            "maxIdleDurationSeconds": args.idle,
+            "suspendedDurationSeconds": args.suspended,
+            "autoResumeEnabled": True,
+        },
+        "maximumDurationInSeconds": args.max_duration,
+    }
+    if args.execution_role_arn:
+        request["executionRoleArn"] = args.execution_role_arn
+    if args.payload:
+        request["runHookPayload"] = args.payload
+
+    response = client.run_microvm(**request)
+    _print(response)
+    _save_last(response["microvmId"], args.region)
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    _print(client.get_microvm(microvmIdentifier=_resolve_id(args.microvm_id)))
+
+
+def cmd_wait(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    _poll_microvm(client, _resolve_id(args.microvm_id), args.target)
+
+
+def cmd_token(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    print(_mint_token(client, _resolve_id(args.microvm_id), args.port, args.minutes))
+
+
+def cmd_exec(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    microvm_id = _resolve_id(args.microvm_id)
+    code = Path(args.file).read_text() if args.file else args.code
+    if not code:
+        sys.exit("pass --code or --file")
+    base_url = _endpoint(client, microvm_id)
+    token = _mint_token(client, microvm_id, args.port, minutes=15)
+    _print(_post_exec(base_url, token, code, args.port))
+
+
+def cmd_suspend(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    microvm_id = _resolve_id(args.microvm_id)
+    client.suspend_microvm(microvmIdentifier=microvm_id)
+    _poll_microvm(client, microvm_id, SUSPENDED)
+
+
+def cmd_resume(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    microvm_id = _resolve_id(args.microvm_id)
+    client.resume_microvm(microvmIdentifier=microvm_id)
+    _poll_microvm(client, microvm_id, RUNNING)
+
+
+def cmd_terminate(args: argparse.Namespace) -> None:
+    client = _client(args.region)
+    microvm_id = _resolve_id(args.microvm_id)
+    client.terminate_microvm(microvmIdentifier=microvm_id)
+    print(f"terminated {microvm_id}")
+
+
+def cmd_demo(args: argparse.Namespace) -> None:
+    """End-to-end showcase: prove session state survives suspend/resume."""
+    client = _client(args.region)
+
+    print("== run ==")
+    request: dict[str, Any] = {
+        "imageIdentifier": _resolve_image(client, args.image),
+        "idlePolicy": {
+            "maxIdleDurationSeconds": 300,
+            "suspendedDurationSeconds": 1800,
+            "autoResumeEnabled": True,
+        },
+        "maximumDurationInSeconds": 3600,
+        "runHookPayload": "demo-session",
+    }
+    if args.execution_role_arn:
+        request["executionRoleArn"] = args.execution_role_arn
+    run_response = client.run_microvm(**request)
+    microvm_id = run_response["microvmId"]
+    _save_last(microvm_id, args.region)
+    print(f"microvmId={microvm_id} endpoint={run_response.get('endpoint')}")
+    _poll_microvm(client, microvm_id, RUNNING)
+
+    base_url = _endpoint(client, microvm_id)
+    token = _mint_token(client, microvm_id, TRAFFIC_PORT, minutes=30)
+
+    print("\n== exec: build up some session state ==")
+    _print(_post_exec(base_url, token, "counter = 100", TRAFFIC_PORT))
+    _print(_post_exec(base_url, token, "counter += 5\nprint(counter)", TRAFFIC_PORT))
+
+    print("\n== suspend ==")
+    client.suspend_microvm(microvmIdentifier=microvm_id)
+    _poll_microvm(client, microvm_id, SUSPENDED)
+
+    print("\n== resume ==")
+    client.resume_microvm(microvmIdentifier=microvm_id)
+    _poll_microvm(client, microvm_id, RUNNING)
+
+    print("\n== exec: state survived the snapshot ==")
+    _print(_post_exec(base_url, token, "print(counter)", TRAFFIC_PORT))
+
+    print("\n== terminate ==")
+    client.terminate_microvm(microvmIdentifier=microvm_id)
+    print(f"terminated {microvm_id}")
+
+
+# --------------------------------------------------------------------------- #
+# argument parsing
+# --------------------------------------------------------------------------- #
+def _add_region(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--region", default=DEFAULT_REGION)
+
+
+def _add_id(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--microvm-id", help="defaults to ./.microvm-last.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="microvm-control", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_build = sub.add_parser("build", help="package image/ and create a MicroVM image")
+    _add_region(p_build)
+    p_build.add_argument("--name", required=True)
+    p_build.add_argument("--artifact-bucket", required=True)
+    p_build.add_argument("--build-role-arn", required=True)
+    p_build.add_argument(
+        "--base-image-arn",
+        required=True,
+        help="Lambda-managed base, e.g. arn:aws:lambda:<region>:aws:microvm-image:al2023-1 "
+        "(discover with `aws lambda-microvms list-managed-microvm-images`)",
+    )
+    p_build.add_argument("--image-dir", default=DEFAULT_IMAGE_DIR)
+    p_build.set_defaults(func=cmd_build)
+
+    p_run = sub.add_parser("run", help="launch a MicroVM from an image")
+    _add_region(p_run)
+    p_run.add_argument("--image", required=True, help="image name or ARN")
+    p_run.add_argument("--execution-role-arn")
+    p_run.add_argument("--payload", help="runHookPayload string (<=4096 bytes)")
+    p_run.add_argument(
+        "--max-duration", type=int, default=3600, help="1..28800 seconds"
+    )
+    p_run.add_argument("--idle", type=int, default=300, help="maxIdleDurationSeconds")
+    p_run.add_argument(
+        "--suspended", type=int, default=1800, help="suspendedDurationSeconds"
+    )
+    p_run.set_defaults(func=cmd_run)
+
+    p_status = sub.add_parser("status", help="get-microvm")
+    _add_region(p_status)
+    _add_id(p_status)
+    p_status.set_defaults(func=cmd_status)
+
+    p_wait = sub.add_parser("wait", help="poll get-microvm until a state")
+    _add_region(p_wait)
+    _add_id(p_wait)
+    p_wait.add_argument("--target", default=RUNNING)
+    p_wait.set_defaults(func=cmd_wait)
+
+    p_token = sub.add_parser("token", help="mint a data-plane auth token")
+    _add_region(p_token)
+    _add_id(p_token)
+    p_token.add_argument("--port", type=int, default=TRAFFIC_PORT)
+    p_token.add_argument("--minutes", type=int, default=15, help="<=60")
+    p_token.set_defaults(func=cmd_token)
+
+    p_exec = sub.add_parser("exec", help="POST code to the sandbox /exec")
+    _add_region(p_exec)
+    _add_id(p_exec)
+    p_exec.add_argument("--code")
+    p_exec.add_argument("--file", help="read code from a file instead of --code")
+    p_exec.add_argument("--port", type=int, default=TRAFFIC_PORT)
+    p_exec.set_defaults(func=cmd_exec)
+
+    for name, func in (
+        ("suspend", cmd_suspend),
+        ("resume", cmd_resume),
+        ("terminate", cmd_terminate),
+    ):
+        p = sub.add_parser(name, help=f"{name}-microvm")
+        _add_region(p)
+        _add_id(p)
+        p.set_defaults(func=func)
+
+    p_demo = sub.add_parser("demo", help="run->exec->suspend->resume->exec->terminate")
+    _add_region(p_demo)
+    p_demo.add_argument("--image", required=True, help="image name or ARN")
+    p_demo.add_argument("--execution-role-arn")
+    p_demo.set_defaults(func=cmd_demo)
+
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/stacks/aws-lambda-microvms/image/Dockerfile
+++ b/stacks/aws-lambda-microvms/image/Dockerfile
@@ -1,0 +1,22 @@
+# This Dockerfile is built by AWS Lambda during `create-microvm-image`: the
+# control CLI zips it together with `src/` and uploads the zip to S3, then Lambda
+# runs this build, starts the app, calls the /ready hook, and snapshots the
+# initialized memory + disk. Every `run-microvm` resumes from that snapshot.
+#
+# MicroVMs run on ARM64 (cpuConfigurations only documents ARM_64).
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/python:3.13-slim
+
+WORKDIR /app
+
+# Deps are pinned here rather than installed from pyproject.toml so the image
+# build stays a plain `pip install` with no build backend in the build context.
+# Keep these in sync with image/pyproject.toml.
+RUN pip install --no-cache-dir "fastapi>=0.116.0" "uvicorn>=0.35.0"
+
+COPY src/microvm_sandbox ./microvm_sandbox
+
+# 8080 = data-plane traffic port (default MicroVM routing target).
+# 9000 = lifecycle-hook control port (must match hooks.port at image creation).
+EXPOSE 8080 9000
+
+CMD ["python", "-m", "microvm_sandbox.main"]

--- a/stacks/aws-lambda-microvms/image/pyproject.toml
+++ b/stacks/aws-lambda-microvms/image/pyproject.toml
@@ -1,0 +1,17 @@
+# A member of the repo-root uv workspace. Dev tooling (ruff/pyright/pytest) and
+# the lockfile live at the workspace root; this file declares only the sandbox's
+# runtime dependencies. NOTE: the container image is built by AWS Lambda from the
+# Dockerfile (not from this file), so the Dockerfile pins fastapi/uvicorn too.
+[project]
+name = "microvm-sandbox"
+version = "0.1.0"
+description = "Code-execution sandbox + lifecycle hooks served inside an AWS Lambda MicroVM"
+requires-python = ">=3.13"
+dependencies = [
+    "fastapi>=0.116.0",
+    "uvicorn>=0.35.0",
+]
+
+[build-system]
+requires = ["uv_build>=0.7.0,<0.9.0"]
+build-backend = "uv_build"

--- a/stacks/aws-lambda-microvms/image/src/microvm_sandbox/__init__.py
+++ b/stacks/aws-lambda-microvms/image/src/microvm_sandbox/__init__.py
@@ -1,0 +1,13 @@
+"""Code-execution sandbox served inside an AWS Lambda MicroVM.
+
+The package runs two ASGI servers in one process (see :mod:`microvm_sandbox.main`):
+
+- the **traffic** server (data-plane port ``8080``) — the ``/exec`` sandbox that
+  runs caller-supplied Python in a persistent session namespace, and
+- the **hooks** server (control port ``9000``) — the MicroVM lifecycle hooks
+  (``/run``, ``/resume``, ``/suspend``, ``/terminate``, plus the build-time
+  ``/ready`` and ``/validate``).
+
+The MicroVM itself is the isolation boundary, so the sandbox runs code directly
+rather than re-sandboxing inside the guest.
+"""

--- a/stacks/aws-lambda-microvms/image/src/microvm_sandbox/hooks.py
+++ b/stacks/aws-lambda-microvms/image/src/microvm_sandbox/hooks.py
@@ -1,0 +1,79 @@
+"""Control-plane app: the MicroVM lifecycle hooks (served on control port 9000).
+
+Lambda calls these over HTTP on the port declared as ``hooks.port`` in
+``create-microvm-image`` (9000 here — distinct from the 8080 traffic port).
+Every hook is a ``POST`` under ``/aws/lambda-microvms/runtime/v1`` and must
+return 200 on success; ``/ready`` returns 503 until the app is up so Lambda can
+poll it during the build. Because Lambda may retry suspend/terminate, the hooks
+are written to be idempotent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Response
+from pydantic import BaseModel
+
+from .session import SESSION
+
+logger = logging.getLogger("microvm.hooks")
+
+app = FastAPI(title="MicroVM lifecycle hooks")
+
+HOOK_PREFIX = "/aws/lambda-microvms/runtime/v1"
+
+
+class RunRequest(BaseModel):
+    # Field names match the JSON Lambda sends to the /run hook.
+    microvmId: str | None = None  # noqa: N815 — wire format is camelCase
+    runHookPayload: str | None = None  # noqa: N815 — wire format is camelCase
+
+
+@app.post(f"{HOOK_PREFIX}/ready")
+def ready() -> Response:
+    """Build-time gate: 200 once the app has initialized, else 503 (Lambda polls)."""
+    return Response(status_code=200 if SESSION.ready else 503)
+
+
+@app.post(f"{HOOK_PREFIX}/validate")
+def validate() -> Response:
+    """Build-time hook; lets Lambda sample touched snapshot pages to prefetch."""
+    return Response(status_code=200)
+
+
+@app.post(f"{HOOK_PREFIX}/run")
+def run(request: RunRequest) -> Response:
+    """Fires once per launch before traffic is forwarded; start a fresh session."""
+    SESSION.start(request.runHookPayload)
+    logger.info(
+        "run hook: microvmId=%s payload=%r", request.microvmId, request.runHookPayload
+    )
+    return Response(status_code=200)
+
+
+@app.post(f"{HOOK_PREFIX}/resume")
+def resume() -> Response:
+    """Fires on SUSPENDED->RUNNING; the VM holds in SUSPENDED until this returns 200.
+
+    Session state is preserved by the snapshot, so we keep it and only refresh
+    ephemeral things. This is where a real app would reseed RNGs and re-open
+    network connections that should not outlive a snapshot.
+    """
+    SESSION.resume_count += 1
+    logger.info("resume hook: resume_count=%d", SESSION.resume_count)
+    return Response(status_code=200)
+
+
+@app.post(f"{HOOK_PREFIX}/suspend")
+def suspend() -> Response:
+    """Fires before RUNNING->SUSPENDED; flush/checkpoint here."""
+    logger.info("suspend hook")
+    return Response(status_code=200)
+
+
+@app.post(f"{HOOK_PREFIX}/terminate")
+def terminate() -> Response:
+    """Fires before the MicroVM's resources are released."""
+    logger.info("terminate hook")
+    return Response(status_code=200)

--- a/stacks/aws-lambda-microvms/image/src/microvm_sandbox/main.py
+++ b/stacks/aws-lambda-microvms/image/src/microvm_sandbox/main.py
@@ -1,0 +1,43 @@
+"""Entrypoint: serve the traffic and hooks apps on their two ports concurrently.
+
+Both listeners bind ``0.0.0.0`` — Lambda reaches the hook port from outside the
+guest, so a localhost-only listener would be unreachable. The control port must
+match ``hooks.port`` passed to ``create-microvm-image`` (9000).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import uvicorn
+
+from .hooks import app as hooks_app
+from .sandbox import app as sandbox_app
+from .session import SESSION
+
+TRAFFIC_PORT = int(os.environ.get("MICROVM_TRAFFIC_PORT", "8080"))
+CONTROL_PORT = int(os.environ.get("MICROVM_CONTROL_PORT", "9000"))
+
+
+async def _serve() -> None:
+    sandbox = uvicorn.Server(
+        uvicorn.Config(sandbox_app, host="0.0.0.0", port=TRAFFIC_PORT, log_level="info")
+    )
+    hooks = uvicorn.Server(
+        uvicorn.Config(hooks_app, host="0.0.0.0", port=CONTROL_PORT, log_level="info")
+    )
+    await asyncio.gather(sandbox.serve(), hooks.serve())
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    SESSION.start(None)
+    # The app is initialized; let the build-time /ready hook report success.
+    SESSION.ready = True
+    asyncio.run(_serve())
+
+
+if __name__ == "__main__":
+    main()

--- a/stacks/aws-lambda-microvms/image/src/microvm_sandbox/sandbox.py
+++ b/stacks/aws-lambda-microvms/image/src/microvm_sandbox/sandbox.py
@@ -1,0 +1,54 @@
+"""Data-plane app: the code-execution sandbox (served on traffic port 8080).
+
+Callers reach these routes through the MicroVM's HTTPS endpoint, which forwards
+to port 8080 by default. The whole surface is one MicroVM = one session: state
+built up here persists in memory across suspend/resume.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .session import SESSION
+
+app = FastAPI(title="MicroVM code-exec sandbox")
+
+
+class ExecRequest(BaseModel):
+    code: str
+
+
+class ExecResponse(BaseModel):
+    ok: bool
+    stdout: str
+    error: str | None = None
+    exec_count: int
+
+
+@app.post("/exec")
+def exec_code(request: ExecRequest) -> ExecResponse:
+    """Run a snippet in the persistent session namespace."""
+    result = SESSION.run_code(request.code)
+    return ExecResponse(
+        ok=result.ok,
+        stdout=result.stdout,
+        error=result.error,
+        exec_count=SESSION.exec_count,
+    )
+
+
+@app.get("/state")
+def state() -> dict[str, object]:
+    """Inspect the live session — handy for showing state survives resume."""
+    return {
+        "exec_count": SESSION.exec_count,
+        "resume_count": SESSION.resume_count,
+        "run_payload": SESSION.run_payload,
+        "variables": SESSION.variables(),
+    }
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/stacks/aws-lambda-microvms/image/src/microvm_sandbox/session.py
+++ b/stacks/aws-lambda-microvms/image/src/microvm_sandbox/session.py
@@ -1,0 +1,77 @@
+"""The in-guest session state shared by the traffic and hooks servers.
+
+A single :class:`Session` instance lives for the life of the MicroVM. Its
+``namespace`` (the variables a caller builds up with ``/exec``) sits in memory,
+so it is preserved by the Firecracker memory snapshot across **suspend/resume** —
+this is what lets a MicroVM hold an interactive session open for hours at low
+idle cost. The lifecycle hooks mutate this same object: ``/run`` starts a fresh
+session (every MicroVM resumes from the *shared* build snapshot, so per-session
+state must be reset), while ``/resume`` only bumps a counter and would be where
+you reseed randomness or re-open connections that should not outlive a snapshot.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import traceback
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecResult:
+    """Outcome of one ``/exec`` call."""
+
+    ok: bool
+    stdout: str
+    error: str | None
+
+
+class Session:
+    """Mutable per-MicroVM session state."""
+
+    def __init__(self) -> None:
+        self.namespace: dict[str, object] = {}
+        self.exec_count: int = 0
+        self.resume_count: int = 0
+        self.run_payload: str | None = None
+        # Flipped on once the app is serving; gates the build-time /ready hook.
+        self.ready: bool = False
+
+    def start(self, run_payload: str | None) -> None:
+        """(Re)initialize the session — called from the ``/run`` hook.
+
+        Resets ``namespace`` so a MicroVM launched from the shared snapshot does
+        not inherit another session's variables.
+        """
+        self.namespace = {"__name__": "__sandbox__"}
+        self.exec_count = 0
+        self.resume_count = 0
+        self.run_payload = run_payload
+
+    def run_code(self, code: str) -> ExecResult:
+        """Execute ``code`` in the persistent namespace, capturing its output.
+
+        Exceptions in caller code are returned as ``error`` rather than raised —
+        a failing snippet is a normal result for a code sandbox, not a 500.
+        """
+        buffer = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+                exec(code, self.namespace)  # the MicroVM is the sandbox boundary
+        except Exception:
+            return ExecResult(
+                ok=False, stdout=buffer.getvalue(), error=traceback.format_exc()
+            )
+        else:
+            return ExecResult(ok=True, stdout=buffer.getvalue(), error=None)
+        finally:
+            self.exec_count += 1
+
+    def variables(self) -> list[str]:
+        """User-defined names currently in the session (dunders hidden)."""
+        return sorted(name for name in self.namespace if not name.startswith("__"))
+
+
+# One session per MicroVM process, imported by both servers.
+SESSION = Session()

--- a/stacks/aws-lambda-microvms/image/tests/test_session.py
+++ b/stacks/aws-lambda-microvms/image/tests/test_session.py
@@ -1,0 +1,41 @@
+"""Unit tests for the in-guest session logic (no AWS, no network)."""
+
+from __future__ import annotations
+
+from microvm_sandbox.session import Session
+
+
+def test_namespace_persists_across_exec() -> None:
+    session = Session()
+    session.start(run_payload=None)
+
+    session.run_code("x = 41")
+    result = session.run_code("print(x + 1)")
+
+    assert result.ok
+    assert result.stdout.strip() == "42"
+    assert session.exec_count == 2
+    assert "x" in session.variables()
+
+
+def test_exception_is_returned_not_raised() -> None:
+    session = Session()
+    session.start(run_payload=None)
+
+    result = session.run_code("1 / 0")
+
+    assert not result.ok
+    assert result.error is not None
+    assert "ZeroDivisionError" in result.error
+
+
+def test_start_resets_namespace() -> None:
+    session = Session()
+    session.start(run_payload="first")
+    session.run_code("leftover = 1")
+
+    session.start(run_payload="second")
+
+    assert session.variables() == []
+    assert session.exec_count == 0
+    assert session.run_payload == "second"

--- a/stacks/aws-lambda-microvms/justfile
+++ b/stacks/aws-lambda-microvms/justfile
@@ -1,0 +1,62 @@
+# Orchestration for the aws-lambda-microvms stack.
+# Requires: terraform, the aws CLI, just, and uv. (No local Docker — AWS Lambda
+# builds the MicroVM image server-side from the uploaded zip.)
+
+tf := "terraform -chdir=terraform"
+region := "us-east-1"
+image_name := "microvm-code-sandbox"
+
+# The control CLI is a uv workspace member; uv discovers the workspace by walking
+# up from here, so it runs with the stack dir as cwd (where .microvm-last.json lands).
+control := "uv run --package microvm-control microvm-control"
+
+default:
+    @just --list
+
+init:
+    {{tf}} init
+
+# Create the S3 artifact bucket and the build/execution IAM roles.
+infra:
+    {{tf}} apply
+
+# Package image/ -> S3 -> create-microvm-image, then wait for the build.
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{control}} build \
+      --region {{region}} \
+      --name {{image_name}} \
+      --image-dir image \
+      --artifact-bucket "$({{tf}} output -raw artifact_bucket)" \
+      --build-role-arn "$({{tf}} output -raw build_role_arn)" \
+      --base-image-arn "$({{tf}} output -raw base_image_arn_hint)"
+
+# Launch a MicroVM from the built image (prints microvmId + endpoint).
+run:
+    {{control}} run --region {{region}} --image {{image_name}} \
+      --execution-role-arn "$({{tf}} output -raw execution_role_arn)"
+
+# Run a code snippet against the last-run MicroVM, e.g. `just exec code='print(2+2)'`.
+exec code='print("hello from the microvm")':
+    {{control}} exec --region {{region}} --code '{{code}}'
+
+status:
+    {{control}} status --region {{region}}
+
+suspend:
+    {{control}} suspend --region {{region}}
+
+resume:
+    {{control}} resume --region {{region}}
+
+terminate:
+    {{control}} terminate --region {{region}}
+
+# Full showcase: run -> exec -> suspend -> resume -> exec (state survived) -> terminate.
+demo:
+    {{control}} demo --region {{region}} --image {{image_name}} \
+      --execution-role-arn "$({{tf}} output -raw execution_role_arn)"
+
+destroy:
+    {{tf}} destroy

--- a/stacks/aws-lambda-microvms/terraform/iam.tf
+++ b/stacks/aws-lambda-microvms/terraform/iam.tf
@@ -1,0 +1,87 @@
+# Two roles Lambda assumes on your behalf. The developer/operator who runs the
+# control CLI uses their own credentials and must additionally be allowed to
+# iam:PassRole these two roles and lambda:PassNetworkConnector (see README).
+
+# --- Build role: assumed during create-microvm-image -----------------------
+data "aws_iam_policy_document" "build_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    # Confused-deputy guard: only this account's MicroVM image builds may assume.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "build_permissions" {
+  statement {
+    sid       = "ReadCodeArtifact"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.artifacts.arn}/*"]
+  }
+  statement {
+    sid       = "BuildLogs"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+resource "aws_iam_role" "build" {
+  name               = "${var.name_prefix}-build"
+  assume_role_policy = data.aws_iam_policy_document.build_assume.json
+}
+
+resource "aws_iam_role_policy" "build" {
+  name   = "build"
+  role   = aws_iam_role.build.id
+  policy = data.aws_iam_policy_document.build_permissions.json
+}
+
+# --- Execution role: assumed by the running MicroVM ------------------------
+# Optional but recommended: without it the app's stdout is not forwarded to
+# CloudWatch. Grant it whatever AWS API permissions your sandbox workload needs;
+# the guest picks up credentials via IMDSv2.
+data "aws_iam_policy_document" "exec_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "exec_permissions" {
+  statement {
+    sid       = "AppLogs"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${var.name_prefix}-execution"
+  assume_role_policy = data.aws_iam_policy_document.exec_assume.json
+}
+
+resource "aws_iam_role_policy" "execution" {
+  name   = "execution"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.exec_permissions.json
+}

--- a/stacks/aws-lambda-microvms/terraform/locals.tf
+++ b/stacks/aws-lambda-microvms/terraform/locals.tf
@@ -1,0 +1,14 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  # Bucket Lambda reads the code artifact (the zipped Dockerfile + src) from.
+  artifact_bucket = "${var.name_prefix}-artifacts-${local.account_id}"
+
+  # The Lambda-managed MicroVM base image (OS + service components). Treated as a
+  # hint output only: the exact suffix can change, so the control CLI lets you
+  # override it. Discover the live list with:
+  #   aws lambda-microvms list-managed-microvm-images --region <region>
+  base_image_arn_hint = "arn:aws:lambda:${var.region}:aws:microvm-image:al2023-1"
+}

--- a/stacks/aws-lambda-microvms/terraform/outputs.tf
+++ b/stacks/aws-lambda-microvms/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "artifact_bucket" {
+  description = "S3 bucket the control CLI uploads the image code artifact to."
+  value       = aws_s3_bucket.artifacts.bucket
+}
+
+output "build_role_arn" {
+  description = "Role Lambda assumes during create-microvm-image."
+  value       = aws_iam_role.build.arn
+}
+
+output "execution_role_arn" {
+  description = "Role the running MicroVM assumes (forwards app stdout to CloudWatch)."
+  value       = aws_iam_role.execution.arn
+}
+
+output "base_image_arn_hint" {
+  description = "Likely Lambda-managed base image ARN; verify with `aws lambda-microvms list-managed-microvm-images`."
+  value       = local.base_image_arn_hint
+}
+
+output "region" {
+  description = "Region the stack is deployed in."
+  value       = var.region
+}

--- a/stacks/aws-lambda-microvms/terraform/provider.tf
+++ b/stacks/aws-lambda-microvms/terraform/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+# Lambda MicroVMs launched at GA in 5 Regions: us-east-1, us-east-2, us-west-2,
+# ap-northeast-1, eu-west-1. Override with `var.region`.
+provider "aws" {
+  region = var.region
+}

--- a/stacks/aws-lambda-microvms/terraform/s3.tf
+++ b/stacks/aws-lambda-microvms/terraform/s3.tf
@@ -1,0 +1,14 @@
+# Lambda's build role reads the code artifact (zipped Dockerfile + src) from this
+# bucket during create-microvm-image. Private; only the build role needs access.
+resource "aws_s3_bucket" "artifacts" {
+  bucket        = local.artifact_bucket
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket                  = aws_s3_bucket.artifacts.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/stacks/aws-lambda-microvms/terraform/variables.tf
+++ b/stacks/aws-lambda-microvms/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "Region to deploy into. Lambda MicroVMs is offered in us-east-1, us-east-2, us-west-2, ap-northeast-1, eu-west-1."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to resource names."
+  type        = string
+  default     = "46ki75-aws-lambda-microvms"
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,8 @@ resolution-markers = [
 members = [
     "agentcore-web-search",
     "ansible-packer",
+    "microvm-control",
+    "microvm-sandbox",
     "python-lambda-adapter",
     "python-lambda-fastapi",
     "python-llama-index",
@@ -378,30 +380,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.34"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/ac/178eb7f96bb6d5771105fe998b8b34512ef3f7ce9e2f1ab8d018df935bee/boto3-1.43.34.tar.gz", hash = "sha256:444207c6c883d4df3ea3b2c36df43ad492b86e0b889eebd2fc1d5ea8db0a8a1a", size = 112656, upload-time = "2026-06-19T19:33:39.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/5f/ac0872df61c3cea3539252f867cf8d76c226e4952f52a981b3fa54381060/boto3-1.43.34-py3-none-any.whl", hash = "sha256:42595057324606928c6e2432b3093978e4d722e0d432bce942f2a385702c0a43", size = 140029, upload-time = "2026-06-19T19:33:37.807Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.34"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/0d/559cdceb9f6acea6b91404970b7973e28a4434fa8a70eb1416b0af478d86/botocore-1.43.34.tar.gz", hash = "sha256:ccc973cf30c6445b30afe5760f6dc949a80f1f862cb23d9c45747f2c814ece77", size = 15591382, upload-time = "2026-06-19T19:33:28.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ea/dc5aab38e2b3f63380810465fab92c836e9e8bce458eba4a8a896f25e1d2/botocore-1.43.34-py3-none-any.whl", hash = "sha256:238a0269f33c5914b9343900b44767e783b3e8b6dcb6e065eac8b4495601c5df", size = 15277590, upload-time = "2026-06-19T19:33:24.562Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
 ]
 
 [[package]]
@@ -1392,6 +1394,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "microvm-control"
+version = "0.1.0"
+source = { editable = "stacks/aws-lambda-microvms/control" }
+dependencies = [
+    { name = "boto3" },
+    { name = "httpx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.43.36" },
+    { name = "httpx", specifier = ">=0.27" },
+]
+
+[[package]]
+name = "microvm-sandbox"
+version = "0.1.0"
+source = { editable = "stacks/aws-lambda-microvms/image" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.116.0" },
+    { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

A runnable `stacks/aws-lambda-microvms/` example of [AWS Lambda MicroVMs](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-lambda-microvms/) — the new serverless primitive for running untrusted user/AI-generated code in VM-isolated, stateful sandboxes that suspend/resume from a Firecracker snapshot.

The example is a **code-execution sandbox**: a MicroVM image that accepts Python over HTTP and runs it in a persistent session whose variables survive suspend/resume.

## Layout

| Path | What |
|------|------|
| `image/` | uv-workspace member — the sandbox baked into the image. `/exec` on the 8080 traffic port; the four lifecycle hooks (`/run`, `/resume`, `/suspend`, `/terminate`, plus build-time `/ready`/`/validate`) on the 9000 control port. The `Dockerfile` is built **by Lambda**, not locally. |
| `control/` | uv-workspace member — `microvm-control`, a boto3 + httpx operator CLI driving the imperative build/run/suspend/resume/terminate lifecycle. |
| `terraform/` | supporting infra only: S3 artifact bucket + build/execution IAM roles. The lifecycle is imperative and lives in the CLI, not in IaC. |
| `justfile` | wires Terraform outputs into the CLI: `infra` → `build` → `run`/`demo`. |

## Notable

- Registers two uv workspace members (`image`, `control`) and bumps **boto3 → ≥1.43.36**, the first release that ships the `lambda-microvms` client.
- Image ops require the full image **ARN** (not the bare name); MicroVM ops take the bare `microvmId`. The CLI resolves names→ARNs.
- Operator IAM: the README documents the needed permissions but does **not** ship a guessed caller policy — the control-plane action prefix (`lambda:` vs `lambda-microvms:`) is unconfirmed in AWS docs.

## Verification

- `ruff`, `pyright` (strict), `pytest` all pass.
- Verified **end-to-end in us-east-1**: `infra` → `build` → `demo` (run → exec → suspend → resume → exec → terminate) with session state (`counter`) surviving the snapshot at `105`. AWS resources have since been torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)