### PR TITLE
Add AWS knowledge MCP configuration

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://opencode.ai/config.json",
+    "lsp": true,
+    "formatter": true,
+    "mcp": {
+        "aws-knowledge": {
+            "type": "remote",
+            "url": "https://knowledge-mcp.global.api.aws",
+            "enabled": true
+        }
+    }
+}


### PR DESCRIPTION
Introduce a configuration for the AWS knowledge MCP, enabling remote access to the AWS knowledge API.